### PR TITLE
Provider auth integration

### DIFF
--- a/.github/workflows/deploy-main-amplify.yml
+++ b/.github/workflows/deploy-main-amplify.yml
@@ -89,7 +89,7 @@ jobs:
         id: resolve
         uses: ./.github/actions/resolve_deploy_env
         with:
-          deploy_paths: '^(client/main/|\.github/workflows/deploy-main-amplify\.yml)'
+          deploy_paths: '^(client/main/|client/packages/|\.github/workflows/deploy-main-amplify\.yml)'
 
   deploy:
     name: 🚀 Trigger Amplify build

--- a/client/main/app/auth/_layout.tsx
+++ b/client/main/app/auth/_layout.tsx
@@ -1,12 +1,16 @@
-import { Redirect, Stack } from 'expo-router';
+import { Redirect, Stack, useSegments } from 'expo-router';
 
 import { useAuth } from '@features/auth';
-import { ROUTES } from '@/utils/route';
+import { ROUTE_NAMES, ROUTES } from '@/utils/route';
 
 export default function AuthLayout() {
   const { session, loading } = useAuth();
+  const segments = useSegments();
 
-  if (!loading && session) {
+  // Never redirect away from /auth/callback — it handles OAuth popup returns
+  const isCallback = segments.includes(ROUTE_NAMES.callback as never);
+
+  if (!loading && session && !isCallback) {
     return <Redirect href={ROUTES.dashboard.home as never} />;
   }
 

--- a/client/main/app/auth/callback/index.tsx
+++ b/client/main/app/auth/callback/index.tsx
@@ -1,33 +1,111 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Text, View } from 'react-native';
+import { maybeCompleteAuthSession } from 'expo-web-browser';
 import { useRouter, useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, View } from 'react-native';
 
 import { useAuth } from '@features/auth';
+import { useTranslation } from '@packages/i18n';
+import type { SocialProvider } from '@features/auth/domain/repositories/auth-repository.port';
+import {
+  OAUTH_STORAGE_KEY,
+  type OAuthPending,
+} from '@features/auth/presentation/hooks/use-social-sign-in';
 import { ROUTES } from '@/utils/route';
+import { isWeb } from '@packages/utils/src';
+
+// Must be called at module level — tells expo-web-browser to close the popup
+// and send the URL back to the opener window via postMessage.
+maybeCompleteAuthSession();
+
+type Status = 'processing' | 'success' | 'error';
 
 export default function AuthCallbackScreen() {
   const router = useRouter();
-  const { code = '' } = useLocalSearchParams<{
-    code: string;
-    state: string;
-  }>();
   const { handleOAuthCallback } = useAuth();
+  const { t } = useTranslation('login');
+  const {
+    code,
+    state,
+    error: oauthError,
+  } = useLocalSearchParams<{ code?: string; state?: string; error?: string }>();
+  const [status, setStatus] = useState<Status>('processing');
+
+  const platformIsWeb = useMemo(() => isWeb(), []);
 
   useEffect(() => {
-    const oauthCode = String(code);
-    if (!oauthCode) {
+    const codeStr = String(code ?? '');
+
+    // OAuth error returned by the provider (e.g. user denied access)
+    if (oauthError || !codeStr) {
       router.replace(ROUTES.authLogin as never);
       return;
     }
 
-    // codeVerifier is stored during OAuth initiation (Fase 7 — social)
-    // For now, redirect to login if no verifier is available
-    router.replace(ROUTES.authLogin as never);
-  }, [code, router, handleOAuthCallback]);
+    // Redirect flow (direct navigation or native deep link without the hook being active).
+    // Read PKCE stored by useSocialSignIn before it triggered the navigation.
+    let pending: OAuthPending | null = null;
+    if (platformIsWeb && typeof sessionStorage !== 'undefined') {
+      try {
+        const stored = sessionStorage.getItem(OAUTH_STORAGE_KEY);
+        if (stored) {
+          pending = JSON.parse(stored) as OAuthPending;
+          sessionStorage.removeItem(OAUTH_STORAGE_KEY);
+        }
+      } catch {
+        // sessionStorage unavailable
+      }
+    }
+
+    if (!pending) {
+      router.replace(ROUTES.authLogin as never);
+      return;
+    }
+
+    const returnedState = String(state ?? '');
+    if (returnedState !== pending.state) {
+      router.replace(ROUTES.authLogin as never);
+      return;
+    }
+
+    handleOAuthCallback(
+      codeStr,
+      pending.codeVerifier,
+      pending.redirectUri,
+      pending.provider as SocialProvider,
+    )
+      .then(() => {
+        setStatus('success');
+        // Brief success state so the user sees the confirmation before navigating.
+        setTimeout(() => {
+          router.replace(ROUTES.dashboard.home as never);
+        }, 600);
+      })
+      .catch(() => {
+        setStatus('error');
+        setTimeout(() => {
+          router.replace(ROUTES.authLogin as never);
+        }, 1200);
+      });
+  }, [code, state, oauthError, router, handleOAuthCallback, platformIsWeb]);
 
   return (
-    <View className="flex-1 items-center justify-center bg-slate-50 dark:bg-slate-900">
-      <ActivityIndicator size="large" />
+    <View className="flex-1 items-center justify-center gap-4 bg-slate-50 dark:bg-slate-900">
+      {status === 'processing' && (
+        <ActivityIndicator size="large" className="text-primary-400" />
+      )}
+      {status === 'success' && (
+        <>
+          <Text className="text-2xl">✓</Text>
+          <Text className="text-slate-700 dark:text-slate-200 text-base">
+            {t('callback.signInSuccess')}
+          </Text>
+        </>
+      )}
+      {status === 'error' && (
+        <Text className="text-red-500 text-base">
+          {t('callback.signInFailed')}
+        </Text>
+      )}
     </View>
   );
 }

--- a/client/main/app/auth/register/index.tsx
+++ b/client/main/app/auth/register/index.tsx
@@ -24,6 +24,9 @@ export default function RegisterScreen() {
     <RegisterPage
       onSignIn={() => router.replace(ROUTES.authLogin as never)}
       onRegisterSuccess={handleRegisterSuccess}
+      onSocialSignInSuccess={() =>
+        router.replace(ROUTES.dashboard.home as never)
+      }
       onPressTerms={() => void Linking.openURL(`${APP_URL}/terms`)}
       onPressPrivacy={() => void Linking.openURL(`${APP_URL}/privacy`)}
     />

--- a/client/main/jest.config.ts
+++ b/client/main/jest.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
     '^@packages/i18n$': '<rootDir>/../packages/i18n/src/index.ts',
     '^@packages/i18n/(.*)$': '<rootDir>/../packages/i18n/src/$1',
     '^@packages/utils$': '<rootDir>/../packages/utils/src/index.ts',
+    '^@packages/utils/(.*)$': '<rootDir>/../packages/utils/$1/index.ts',
     '^@features/auth$': '<rootDir>/../packages/features/auth/src/index.ts',
     '^@features/auth/(.*)$': '<rootDir>/../packages/features/auth/src/$1',
     '^@features/dashboard$':
@@ -40,6 +41,7 @@ const config: Config = {
     '^@expo/vector-icons$': '<rootDir>/tests/__mocks__/expo-vector-icons.ts',
     '^nativewind$': '<rootDir>/tests/__mocks__/nativewind.ts',
     '^expo-linking$': '<rootDir>/tests/__mocks__/expo-linking.ts',
+    '^expo-web-browser$': '<rootDir>/tests/__mocks__/expo-web-browser.ts',
     '^react-native-qrcode-svg$':
       '<rootDir>/tests/__mocks__/react-native-qrcode-svg.ts',
     '^amazon-cognito-identity-js$':

--- a/client/main/tests/__mocks__/expo-web-browser.ts
+++ b/client/main/tests/__mocks__/expo-web-browser.ts
@@ -1,0 +1,12 @@
+module.exports = {
+  maybeCompleteAuthSession: jest.fn().mockReturnValue({ type: 'failed' }),
+  openAuthSessionAsync: jest.fn().mockResolvedValue({ type: 'cancel' }),
+  openBrowserAsync: jest.fn().mockResolvedValue({ type: 'cancel' }),
+  dismissBrowser: jest.fn(),
+  WebBrowserResultType: {
+    CANCEL: 'cancel',
+    DISMISS: 'dismiss',
+    OPENED: 'opened',
+    LOCKED: 'locked',
+  },
+};

--- a/client/main/tests/app/auth/callback/index.test.ts
+++ b/client/main/tests/app/auth/callback/index.test.ts
@@ -1,0 +1,22 @@
+import AuthCallbackScreen from '@/app/auth/callback';
+import { ROUTES } from '@/utils/route';
+
+describe('app/auth/callback/index', () => {
+  it('module exports a default function', () => {
+    expect(typeof AuthCallbackScreen).toBe('function');
+  });
+
+  it('AuthCallbackScreen has the expected name', () => {
+    expect(AuthCallbackScreen.name).toBe('AuthCallbackScreen');
+  });
+
+  describe('route configuration', () => {
+    it('ROUTES.authCallback is defined', () => {
+      expect(ROUTES.authCallback).toBeDefined();
+    });
+
+    it('ROUTES.authCallback points to the callback path', () => {
+      expect(ROUTES.authCallback).toBe('/auth/callback');
+    });
+  });
+});

--- a/client/main/tests/app/auth/forgot-password/confirm/index.test.ts
+++ b/client/main/tests/app/auth/forgot-password/confirm/index.test.ts
@@ -1,0 +1,26 @@
+import ForgotPasswordConfirmScreen from '@/app/auth/forgot-password/confirm';
+import { ROUTES } from '@/utils/route';
+
+describe('app/auth/forgot-password/confirm/index', () => {
+  it('module exports a default function', () => {
+    expect(typeof ForgotPasswordConfirmScreen).toBe('function');
+  });
+
+  it('ForgotPasswordConfirmScreen has the expected name', () => {
+    expect(ForgotPasswordConfirmScreen.name).toBe(
+      'ForgotPasswordConfirmScreen',
+    );
+  });
+
+  describe('route configuration', () => {
+    it('ROUTES.authForgotPasswordConfirm is defined', () => {
+      expect(ROUTES.authForgotPasswordConfirm).toBeDefined();
+    });
+
+    it('ROUTES.authForgotPasswordConfirm points to the confirm path', () => {
+      expect(ROUTES.authForgotPasswordConfirm).toBe(
+        '/auth/forgot-password/confirm',
+      );
+    });
+  });
+});

--- a/client/main/tests/app/auth/mfa/index.test.ts
+++ b/client/main/tests/app/auth/mfa/index.test.ts
@@ -1,0 +1,22 @@
+import MfaScreen from '@/app/auth/mfa';
+import { ROUTES } from '@/utils/route';
+
+describe('app/auth/mfa/index', () => {
+  it('module exports a default function', () => {
+    expect(typeof MfaScreen).toBe('function');
+  });
+
+  it('MfaScreen has the expected name', () => {
+    expect(MfaScreen.name).toBe('MfaScreen');
+  });
+
+  describe('route configuration', () => {
+    it('ROUTES.authMfa is defined', () => {
+      expect(ROUTES.authMfa).toBeDefined();
+    });
+
+    it('ROUTES.authMfa points to the mfa path', () => {
+      expect(ROUTES.authMfa).toBe('/auth/mfa');
+    });
+  });
+});

--- a/client/main/tests/app/auth/mfa/setup/index.test.ts
+++ b/client/main/tests/app/auth/mfa/setup/index.test.ts
@@ -1,0 +1,22 @@
+import MfaSetupScreen from '@/app/auth/mfa/setup';
+import { ROUTES } from '@/utils/route';
+
+describe('app/auth/mfa/setup/index', () => {
+  it('module exports a default function', () => {
+    expect(typeof MfaSetupScreen).toBe('function');
+  });
+
+  it('MfaSetupScreen has the expected name', () => {
+    expect(MfaSetupScreen.name).toBe('MfaSetupScreen');
+  });
+
+  describe('route configuration', () => {
+    it('ROUTES.authMfaSetup is defined', () => {
+      expect(ROUTES.authMfaSetup).toBeDefined();
+    });
+
+    it('ROUTES.authMfaSetup points to the mfa setup path', () => {
+      expect(ROUTES.authMfaSetup).toBe('/auth/mfa/setup');
+    });
+  });
+});

--- a/client/main/tests/app/auth/new-password/index.test.ts
+++ b/client/main/tests/app/auth/new-password/index.test.ts
@@ -1,0 +1,22 @@
+import NewPasswordScreen from '@/app/auth/new-password';
+import { ROUTES } from '@/utils/route';
+
+describe('app/auth/new-password/index', () => {
+  it('module exports a default function', () => {
+    expect(typeof NewPasswordScreen).toBe('function');
+  });
+
+  it('NewPasswordScreen has the expected name', () => {
+    expect(NewPasswordScreen.name).toBe('NewPasswordScreen');
+  });
+
+  describe('route configuration', () => {
+    it('ROUTES.authNewPassword is defined', () => {
+      expect(ROUTES.authNewPassword).toBeDefined();
+    });
+
+    it('ROUTES.authNewPassword points to the new-password path', () => {
+      expect(ROUTES.authNewPassword).toBe('/auth/new-password');
+    });
+  });
+});

--- a/client/main/tests/app/auth/register/confirm/index.test.ts
+++ b/client/main/tests/app/auth/register/confirm/index.test.ts
@@ -1,0 +1,22 @@
+import RegisterConfirmScreen from '@/app/auth/register/confirm';
+import { ROUTES } from '@/utils/route';
+
+describe('app/auth/register/confirm/index', () => {
+  it('module exports a default function', () => {
+    expect(typeof RegisterConfirmScreen).toBe('function');
+  });
+
+  it('RegisterConfirmScreen has the expected name', () => {
+    expect(RegisterConfirmScreen.name).toBe('RegisterConfirmScreen');
+  });
+
+  describe('route configuration', () => {
+    it('ROUTES.authRegisterConfirm is defined', () => {
+      expect(ROUTES.authRegisterConfirm).toBeDefined();
+    });
+
+    it('ROUTES.authRegisterConfirm points to the confirm path', () => {
+      expect(ROUTES.authRegisterConfirm).toBe('/auth/register/confirm');
+    });
+  });
+});

--- a/client/main/utils/route.ts
+++ b/client/main/utils/route.ts
@@ -29,4 +29,5 @@ export const ROUTE_NAMES = {
   terms: 'terms',
   contact: 'contact',
   notFound: '+not-found',
+  callback: 'callback',
 };

--- a/client/packages/features/auth/jest.config.ts
+++ b/client/packages/features/auth/jest.config.ts
@@ -26,6 +26,7 @@ const config: Config = {
     '^nativewind$': '<rootDir>/src/__mocks__/nativewind.ts',
     '^expo-crypto$': '<rootDir>/src/__mocks__/expo-crypto.ts',
     '^expo-linking$': '<rootDir>/src/__mocks__/expo-linking.ts',
+    '^expo-web-browser$': '<rootDir>/src/__mocks__/expo-web-browser.ts',
     '^react-native-qrcode-svg$':
       '<rootDir>/src/__mocks__/react-native-qrcode-svg.ts',
     // libphonenumber-js is pure JS — no mock needed, real module works in Node

--- a/client/packages/features/auth/src/__mocks__/expo-web-browser.ts
+++ b/client/packages/features/auth/src/__mocks__/expo-web-browser.ts
@@ -1,0 +1,3 @@
+module.exports = {
+  openAuthSessionAsync: jest.fn().mockResolvedValue({ type: 'cancel' }),
+};

--- a/client/packages/features/auth/src/application/use-cases/__mocks__/auth-repository.mock.ts
+++ b/client/packages/features/auth/src/application/use-cases/__mocks__/auth-repository.mock.ts
@@ -15,6 +15,7 @@ export function createMockAuthRepository(): jest.Mocked<AuthRepository> {
     associateSoftwareToken: jest.fn(),
     verifySoftwareToken: jest.fn(),
     getCurrentUser: jest.fn(),
+    updateUserAttribute: jest.fn(),
     refreshSession: jest.fn(),
     signOut: jest.fn(),
   };

--- a/client/packages/features/auth/src/domain/entities/user.ts
+++ b/client/packages/features/auth/src/domain/entities/user.ts
@@ -7,6 +7,8 @@ export interface User {
   readonly birthdate?: string;
   readonly profilePicture?: string;
   readonly locale?: string;
+  /** Provider-specific user ID (e.g. Facebook user ID). Populated from Cognito's `identities` attribute. */
+  readonly providerUserId?: string;
   readonly address?: string;
   readonly lastUpdateTime?: Date;
   readonly emailVerified: boolean;

--- a/client/packages/features/auth/src/domain/repositories/auth-repository.port.ts
+++ b/client/packages/features/auth/src/domain/repositories/auth-repository.port.ts
@@ -101,6 +101,8 @@ export interface AuthRepository {
 
   getCurrentUser(): Promise<User | null>;
 
+  updateUserAttribute(name: string, value: string): Promise<void>;
+
   refreshSession(): Promise<AuthSession>;
 
   signOut(): Promise<void>;

--- a/client/packages/features/auth/src/index.ts
+++ b/client/packages/features/auth/src/index.ts
@@ -1,5 +1,9 @@
 // Auth Provider + context
 export { AuthProvider, useAuth } from './presentation/providers/auth-provider';
+
+// Hooks
+export { useSocialSignIn } from './presentation/hooks/use-social-sign-in';
+export type { UseSocialSignInResult } from './presentation/hooks/use-social-sign-in';
 export type {
   AuthState,
   AuthContextValue,

--- a/client/packages/features/auth/src/infrastructure/cognito/cognito-auth-repository.test.ts
+++ b/client/packages/features/auth/src/infrastructure/cognito/cognito-auth-repository.test.ts
@@ -112,6 +112,7 @@ type MockCognitoUser = {
   globalSignOut: jest.Mock;
   signOut: jest.Mock;
   refreshSession: jest.Mock;
+  setSignInUserSession: jest.Mock;
 };
 
 type MockPool = {
@@ -136,6 +137,7 @@ function makeMockUser(): MockCognitoUser {
     globalSignOut: jest.fn(),
     signOut: jest.fn(),
     refreshSession: jest.fn(),
+    setSignInUserSession: jest.fn(),
   };
 }
 

--- a/client/packages/features/auth/src/infrastructure/cognito/cognito-auth-repository.test.ts
+++ b/client/packages/features/auth/src/infrastructure/cognito/cognito-auth-repository.test.ts
@@ -25,6 +25,16 @@ jest.mock('./cognito-config', () => ({
   },
 }));
 
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const parts = token.split('.');
+  const base64 = (parts[1] ?? '').replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    '=',
+  );
+  return JSON.parse(Buffer.from(padded, 'base64').toString());
+}
+
 jest.mock('amazon-cognito-identity-js', () => ({
   CognitoUserPool: jest.fn(),
   CognitoUser: jest.fn(),
@@ -35,6 +45,49 @@ jest.mock('amazon-cognito-identity-js', () => ({
       getValue: () => Value,
     })),
   AuthenticationDetails: jest.fn(),
+  CognitoAccessToken: jest
+    .fn()
+    .mockImplementation(({ AccessToken }: { AccessToken: string }) => ({
+      payload: decodeJwtPayload(AccessToken),
+      getJwtToken: () => AccessToken,
+      getExpiration: () => Math.floor(Date.now() / 1000) + 3600,
+    })),
+  CognitoIdToken: jest
+    .fn()
+    .mockImplementation(({ IdToken }: { IdToken: string }) => ({
+      payload: {},
+      getJwtToken: () => IdToken,
+    })),
+  CognitoRefreshToken: jest
+    .fn()
+    .mockImplementation(({ RefreshToken }: { RefreshToken: string }) => ({
+      getToken: () => RefreshToken,
+    })),
+  CognitoUserSession: jest.fn().mockImplementation(
+    (parts: {
+      AccessToken: {
+        payload: Record<string, unknown>;
+        getJwtToken: () => string;
+        getExpiration: () => number;
+      };
+      IdToken: {
+        payload: Record<string, unknown>;
+        getJwtToken: () => string;
+      };
+      RefreshToken: { getToken: () => string };
+    }) => ({
+      getAccessToken: () => parts.AccessToken,
+      getIdToken: () => ({
+        ...parts.IdToken,
+        payload: {
+          ...parts.IdToken.payload,
+          sub: parts.AccessToken.payload['sub'],
+        },
+      }),
+      getRefreshToken: () => parts.RefreshToken,
+      isValid: () => true,
+    }),
+  ),
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -338,6 +391,20 @@ describe('CognitoAuthRepository', () => {
         (cb: (err: Error, session: null) => void) => {
           cb(new Error('expired'), null);
         },
+      );
+
+      await expect(repo.getCurrentUser()).resolves.toBeNull();
+    });
+
+    it('returns null when getUserAttributes fails', async () => {
+      const session = makeMockSession();
+      mockPool.getCurrentUser.mockReturnValue(mockUser);
+      mockUser.getSession.mockImplementation(
+        (cb: (err: null, s: unknown) => void) => cb(null, session),
+      );
+      mockUser.getUserAttributes.mockImplementation(
+        (cb: (err: Error, attrs: null) => void) =>
+          cb(new Error('failed'), null),
       );
 
       await expect(repo.getCurrentUser()).resolves.toBeNull();

--- a/client/packages/features/auth/src/infrastructure/cognito/cognito-auth-repository.ts
+++ b/client/packages/features/auth/src/infrastructure/cognito/cognito-auth-repository.ts
@@ -1,5 +1,8 @@
 import {
   AuthenticationDetails,
+  CognitoAccessToken,
+  CognitoIdToken,
+  CognitoRefreshToken,
   CognitoUser,
   CognitoUserAttribute,
   CognitoUserPool,
@@ -135,7 +138,9 @@ export class CognitoAuthRepository implements AuthRepository {
     newPassword: string,
   ): Promise<AuthChallengeResult> {
     const entry = this.pending.get(session);
-    if (!entry) throw new NotAuthorizedException();
+    if (!entry) {
+      throw new NotAuthorizedException();
+    }
 
     return new Promise((resolve, reject) => {
       entry.user.completeNewPasswordChallenge(
@@ -174,7 +179,9 @@ export class CognitoAuthRepository implements AuthRepository {
     challengeName: MfaType,
   ): Promise<AuthSession> {
     const entry = this.pending.get(session);
-    if (!entry) throw new NotAuthorizedException();
+    if (!entry) {
+      throw new NotAuthorizedException();
+    }
 
     return new Promise((resolve, reject) => {
       entry.user.sendMFACode(
@@ -260,7 +267,7 @@ export class CognitoAuthRepository implements AuthRepository {
       client_id: cognitoConfig.clientId,
       redirect_uri: redirectUri,
       identity_provider: PROVIDER_MAP[provider],
-      scope: 'openid email profile',
+      scope: 'openid email profile phone aws.cognito.signin.user.admin',
       code_challenge: pkce.codeChallenge,
       code_challenge_method: 'S256',
       state: pkce.state,
@@ -302,14 +309,33 @@ export class CognitoAuthRepository implements AuthRepository {
       expires_in: number;
     };
 
-    const payload = this.decodeJwtPayload(data.access_token);
-    return {
-      accessToken: data.access_token,
-      idToken: data.id_token,
-      refreshToken: data.refresh_token,
-      expiresAt: new Date(Date.now() + data.expires_in * 1_000),
-      userId: payload['sub'] as string,
-    };
+    // Inject the session into the SDK so that getCurrentUser() / refreshSession()
+    // work the same way as they do after a regular signIn flow.
+    const accessToken = new CognitoAccessToken({
+      AccessToken: data.access_token,
+    });
+    const idToken = new CognitoIdToken({ IdToken: data.id_token });
+    const refreshToken = new CognitoRefreshToken({
+      RefreshToken: data.refresh_token,
+    });
+
+    const cognitoSession = new CognitoUserSession({
+      AccessToken: accessToken,
+      IdToken: idToken,
+      RefreshToken: refreshToken,
+    });
+
+    const username =
+      (accessToken.payload['username'] as string | undefined) ??
+      (accessToken.payload['sub'] as string);
+
+    const cognitoUser = new CognitoUser({
+      Username: username,
+      Pool: this.pool,
+    });
+    cognitoUser.setSignInUserSession(cognitoSession);
+
+    return this.mapSession(cognitoSession);
   }
 
   // ── Forgot password ──────────────────────────────────────────────────────
@@ -362,7 +388,9 @@ export class CognitoAuthRepository implements AuthRepository {
     session: string,
   ): Promise<{ secretCode: string; qrCodeUrl: string }> {
     const entry = this.pending.get(session);
-    if (!entry) throw new NotAuthorizedException();
+    if (!entry) {
+      throw new NotAuthorizedException();
+    }
 
     return new Promise((resolve, reject) => {
       entry.user.associateSoftwareToken({
@@ -383,7 +411,9 @@ export class CognitoAuthRepository implements AuthRepository {
     deviceName: string,
   ): Promise<AuthSession> {
     const entry = this.pending.get(session);
-    if (!entry) throw new NotAuthorizedException();
+    if (!entry) {
+      throw new NotAuthorizedException();
+    }
 
     return new Promise((resolve, reject) => {
       entry.user.verifySoftwareToken(code, deviceName, {
@@ -396,10 +426,37 @@ export class CognitoAuthRepository implements AuthRepository {
     });
   }
 
+  // ── User attributes ──────────────────────────────────────────────────────
+
+  async updateUserAttribute(name: string, value: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const cognitoUser = this.pool.getCurrentUser();
+      if (!cognitoUser) {
+        return reject(new NotAuthorizedException());
+      }
+
+      cognitoUser.getSession(
+        (err: Error | null, session: CognitoUserSession | null) => {
+          if (err || !session?.isValid()) {
+            return reject(new NotAuthorizedException());
+          }
+
+          const attributes = [
+            new CognitoUserAttribute({ Name: name, Value: value }),
+          ];
+          cognitoUser.updateAttributes(attributes, (attrErr) => {
+            if (attrErr) return reject(this.mapError(attrErr));
+            resolve();
+          });
+        },
+      );
+    });
+  }
+
   // ── Session management ───────────────────────────────────────────────────
 
   async getCurrentUser(): Promise<User | null> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const cognitoUser = this.pool.getCurrentUser();
       if (!cognitoUser) return resolve(null);
 
@@ -408,7 +465,7 @@ export class CognitoAuthRepository implements AuthRepository {
           if (err || !session?.isValid()) return resolve(null);
 
           cognitoUser.getUserAttributes((attrErr, attributes) => {
-            if (attrErr || !attributes) return reject(this.mapError(attrErr));
+            if (attrErr || !attributes) return resolve(null);
             const userId = session.getIdToken().payload['sub'] as string;
             resolve(this.mapUserAttributes(attributes, userId));
           });
@@ -420,7 +477,9 @@ export class CognitoAuthRepository implements AuthRepository {
   async refreshSession(): Promise<AuthSession> {
     return new Promise((resolve, reject) => {
       const cognitoUser = this.pool.getCurrentUser();
-      if (!cognitoUser) return reject(new NotAuthorizedException());
+      if (!cognitoUser) {
+        return reject(new NotAuthorizedException());
+      }
 
       cognitoUser.getSession(
         (err: Error | null, session: CognitoUserSession | null) => {
@@ -482,6 +541,20 @@ export class CognitoAuthRepository implements AuthRepository {
     const get = (name: string) =>
       attributes.find((a) => a.getName() === name)?.getValue();
     const updatedAtRaw = get('updated_at');
+
+    let providerUserId: string | undefined;
+    const identitiesRaw = get('identities');
+    if (identitiesRaw) {
+      try {
+        const identities = JSON.parse(identitiesRaw) as Array<{
+          userId?: string;
+        }>;
+        providerUserId = identities[0]?.userId;
+      } catch {
+        // identities attribute is malformed — ignore
+      }
+    }
+
     return {
       userId,
       email: get('email') ?? '',
@@ -497,20 +570,8 @@ export class CognitoAuthRepository implements AuthRepository {
         : undefined,
       emailVerified: get('email_verified') === 'true',
       phoneVerified: get('phone_number_verified') === 'true',
+      providerUserId,
     };
-  }
-
-  private decodeJwtPayload(token: string): Record<string, unknown> {
-    const parts = token.split('.');
-    if (parts.length < 2 || !parts[1]) {
-      throw new UnknownAuthException('Invalid JWT: missing payload segment');
-    }
-    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      '=',
-    );
-    return JSON.parse(atob(padded)) as Record<string, unknown>;
   }
 
   private mapError(err: unknown): Error {

--- a/client/packages/features/auth/src/presentation/hooks/use-social-sign-in.test.ts
+++ b/client/packages/features/auth/src/presentation/hooks/use-social-sign-in.test.ts
@@ -3,6 +3,8 @@ import { createURL } from 'expo-linking';
 
 import { OAUTH_STORAGE_KEY } from './use-social-sign-in';
 
+import { useSocialSignIn } from './use-social-sign-in';
+
 // ── React hooks mock ─────────────────────────────────────────────────────────
 // Allow calling the hook outside a component by shimming useState / useCallback.
 // We use a shared state store so that setState calls are visible to the test
@@ -99,10 +101,6 @@ function getHookState(baseIndex: number) {
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const mod =
-  require('./use-social-sign-in') as typeof import('./use-social-sign-in');
-
 // ── sessionStorage polyfill ──────────────────────────────────────────────────
 
 const storage = new Map<string, string>();
@@ -134,13 +132,13 @@ describe('useSocialSignIn', () => {
   });
 
   it('exports useSocialSignIn as a function', () => {
-    expect(typeof mod.useSocialSignIn).toBe('function');
-    expect(mod.useSocialSignIn.name).toBe('useSocialSignIn');
+    expect(typeof useSocialSignIn).toBe('function');
+    expect(useSocialSignIn.name).toBe('useSocialSignIn');
   });
 
   it('returns initiate, loading, and error', () => {
     baseIndex = stateCounter;
-    const result = mod.useSocialSignIn(jest.fn());
+    const result = useSocialSignIn(jest.fn());
     expect(typeof result.initiate).toBe('function');
     const state = getHookState(baseIndex);
     expect(state.loading).toBe(false);
@@ -151,7 +149,7 @@ describe('useSocialSignIn', () => {
     it('calls getOAuthSignInUrl with provider and redirect URI', async () => {
       setupMocks();
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
 
       expect(mockGetOAuthSignInUrl).toHaveBeenCalledWith(
@@ -163,7 +161,7 @@ describe('useSocialSignIn', () => {
     it('opens auth session with the OAuth URL', async () => {
       setupMocks();
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
 
       expect(openAuthSessionAsync).toHaveBeenCalledWith(
@@ -175,7 +173,7 @@ describe('useSocialSignIn', () => {
     it('calls handleOAuthCallback with code, verifier, redirect, provider, and locale', async () => {
       setupMocks();
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn(), 'es');
+      const { initiate } = useSocialSignIn(jest.fn(), 'es');
       await initiate('facebook');
 
       expect(mockHandleOAuthCallback).toHaveBeenCalledWith(
@@ -191,7 +189,7 @@ describe('useSocialSignIn', () => {
       setupMocks();
       const onSuccess = jest.fn();
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(onSuccess);
+      const { initiate } = useSocialSignIn(onSuccess);
       await initiate('google');
 
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -200,7 +198,7 @@ describe('useSocialSignIn', () => {
     it('clears sessionStorage after successful popup flow', async () => {
       setupMocks();
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
 
       expect(storage.has(OAUTH_STORAGE_KEY)).toBe(false);
@@ -226,7 +224,7 @@ describe('useSocialSignIn', () => {
       });
 
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
 
       expect(storedValue).not.toBeNull();
@@ -244,7 +242,7 @@ describe('useSocialSignIn', () => {
     it('does not call handleOAuthCallback when user cancels', async () => {
       setupMocks({ authSessionResult: { type: 'cancel' } });
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
 
       expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
@@ -254,7 +252,7 @@ describe('useSocialSignIn', () => {
       setupMocks({ authSessionResult: { type: 'dismiss' } });
       const onSuccess = jest.fn();
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(onSuccess);
+      const { initiate } = useSocialSignIn(onSuccess);
       await initiate('google');
 
       expect(onSuccess).not.toHaveBeenCalled();
@@ -271,7 +269,7 @@ describe('useSocialSignIn', () => {
       });
 
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
       const state = getHookState(baseIndex);
 
@@ -288,7 +286,7 @@ describe('useSocialSignIn', () => {
       });
 
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
       const state = getHookState(baseIndex);
 
@@ -304,7 +302,7 @@ describe('useSocialSignIn', () => {
       mockGetOAuthSignInUrl.mockRejectedValue(new Error('Network failure'));
 
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
       const state = getHookState(baseIndex);
 
@@ -318,7 +316,7 @@ describe('useSocialSignIn', () => {
       );
 
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
       const state = getHookState(baseIndex);
 
@@ -330,7 +328,7 @@ describe('useSocialSignIn', () => {
       mockHandleOAuthCallback.mockRejectedValue(new Error('fail'));
 
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
 
       expect(storage.has(OAUTH_STORAGE_KEY)).toBe(false);
@@ -343,7 +341,7 @@ describe('useSocialSignIn', () => {
       mockGetOAuthSignInUrl.mockRejectedValue('string error');
 
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
       const state = getHookState(baseIndex);
 
@@ -369,7 +367,7 @@ describe('useSocialSignIn', () => {
       (openAuthSessionAsync as jest.Mock).mockResolvedValue({ type: 'cancel' });
 
       baseIndex = stateCounter;
-      const { initiate } = mod.useSocialSignIn(jest.fn());
+      const { initiate } = useSocialSignIn(jest.fn());
       await initiate('google');
       const state = getHookState(baseIndex);
 

--- a/client/packages/features/auth/src/presentation/hooks/use-social-sign-in.test.ts
+++ b/client/packages/features/auth/src/presentation/hooks/use-social-sign-in.test.ts
@@ -1,0 +1,11 @@
+import { useSocialSignIn } from './use-social-sign-in';
+
+describe('useSocialSignIn', () => {
+  it('exports useSocialSignIn as a function', () => {
+    expect(typeof useSocialSignIn).toBe('function');
+  });
+
+  it('has the expected name', () => {
+    expect(useSocialSignIn.name).toBe('useSocialSignIn');
+  });
+});

--- a/client/packages/features/auth/src/presentation/hooks/use-social-sign-in.test.ts
+++ b/client/packages/features/auth/src/presentation/hooks/use-social-sign-in.test.ts
@@ -1,11 +1,386 @@
-import { useSocialSignIn } from './use-social-sign-in';
+import { openAuthSessionAsync } from 'expo-web-browser';
+import { createURL } from 'expo-linking';
+
+import { OAUTH_STORAGE_KEY } from './use-social-sign-in';
+
+// ── React hooks mock ─────────────────────────────────────────────────────────
+// Allow calling the hook outside a component by shimming useState / useCallback.
+// We use a shared state store so that setState calls are visible to the test
+// after `initiate` resolves.
+
+const stateStore = new Map<number, unknown>();
+let stateCounter = 0;
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useState: <T>(initial: T): [T, (v: T) => void] => {
+    const id = stateCounter++;
+    stateStore.set(id, initial);
+    const getter = () => stateStore.get(id) as T;
+    const setter = (v: T) => {
+      stateStore.set(id, v);
+    };
+    // Return a proxy array so reads always resolve latest value
+    return new Proxy([initial, setter] as [T, (v: T) => void], {
+      get(target, prop, receiver) {
+        if (prop === '0') return getter();
+        if (prop === '1') return setter;
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+  },
+  useCallback: <T>(fn: T): T => fn,
+}));
+
+// ── Auth mock ────────────────────────────────────────────────────────────────
+
+const mockGetOAuthSignInUrl = jest.fn();
+const mockHandleOAuthCallback = jest.fn();
+
+jest.mock('@features/auth/presentation/providers/auth-provider', () => ({
+  useAuth: () => ({
+    getOAuthSignInUrl: mockGetOAuthSignInUrl,
+    handleOAuthCallback: mockHandleOAuthCallback,
+  }),
+}));
+
+// Platform.OS is 'web' in the react-native mock, so isWeb() returns true.
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_PKCE = {
+  codeVerifier: 'verifier-abc',
+  codeChallenge: 'challenge-abc',
+  state: 'state-xyz',
+};
+
+function makeSuccessUrl(code: string, state: string) {
+  return `https://localhost/auth/callback?code=${code}&state=${state}`;
+}
+
+function setupMocks(
+  overrides: {
+    authSessionResult?: { type: string; url?: string };
+    pkce?: typeof DEFAULT_PKCE;
+  } = {},
+) {
+  const pkce = overrides.pkce ?? DEFAULT_PKCE;
+
+  (createURL as jest.Mock).mockReturnValue('https://localhost/auth/callback');
+  mockGetOAuthSignInUrl.mockResolvedValue({
+    url: 'https://cognito.example.com/oauth2/authorize?...',
+    pkce,
+  });
+  mockHandleOAuthCallback.mockResolvedValue(undefined);
+  (openAuthSessionAsync as jest.Mock).mockResolvedValue(
+    overrides.authSessionResult ?? {
+      type: 'success',
+      url: makeSuccessUrl('auth-code-123', pkce.state),
+    },
+  );
+}
+
+/**
+ * The hook destructures `const [error, setError] = useState(null)`.
+ * Because we mocked useState with a Proxy, the destructured `error` variable
+ * captures the initial value. To read the *latest* state after `initiate`
+ * runs, we read directly from the stateStore.
+ *
+ * State layout per hook call: index 0 = loading, index 1 = error.
+ */
+function getHookState(baseIndex: number) {
+  return {
+    get loading() {
+      return stateStore.get(baseIndex) as boolean;
+    },
+    get error() {
+      return stateStore.get(baseIndex + 1) as string | null;
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mod =
+  require('./use-social-sign-in') as typeof import('./use-social-sign-in');
+
+// ── sessionStorage polyfill ──────────────────────────────────────────────────
+
+const storage = new Map<string, string>();
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).sessionStorage = {
+    getItem: (k: string) => storage.get(k) ?? null,
+    setItem: (k: string, v: string) => storage.set(k, v),
+    removeItem: (k: string) => storage.delete(k),
+    clear: () => storage.clear(),
+  };
+});
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).sessionStorage;
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('useSocialSignIn', () => {
-  it('exports useSocialSignIn as a function', () => {
-    expect(typeof useSocialSignIn).toBe('function');
+  let baseIndex: number;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage.clear();
+    // Record the stateStore counter before each hook call
+    // so we know which indices belong to this test's hook instance
+    baseIndex = stateCounter;
   });
 
-  it('has the expected name', () => {
-    expect(useSocialSignIn.name).toBe('useSocialSignIn');
+  it('exports useSocialSignIn as a function', () => {
+    expect(typeof mod.useSocialSignIn).toBe('function');
+    expect(mod.useSocialSignIn.name).toBe('useSocialSignIn');
+  });
+
+  it('returns initiate, loading, and error', () => {
+    baseIndex = stateCounter;
+    const result = mod.useSocialSignIn(jest.fn());
+    expect(typeof result.initiate).toBe('function');
+    const state = getHookState(baseIndex);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  describe('successful popup flow', () => {
+    it('calls getOAuthSignInUrl with provider and redirect URI', async () => {
+      setupMocks();
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+
+      expect(mockGetOAuthSignInUrl).toHaveBeenCalledWith(
+        'google',
+        'https://localhost/auth/callback',
+      );
+    });
+
+    it('opens auth session with the OAuth URL', async () => {
+      setupMocks();
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+
+      expect(openAuthSessionAsync).toHaveBeenCalledWith(
+        'https://cognito.example.com/oauth2/authorize?...',
+        'https://localhost/auth/callback',
+      );
+    });
+
+    it('calls handleOAuthCallback with code, verifier, redirect, provider, and locale', async () => {
+      setupMocks();
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn(), 'es');
+      await initiate('facebook');
+
+      expect(mockHandleOAuthCallback).toHaveBeenCalledWith(
+        'auth-code-123',
+        DEFAULT_PKCE.codeVerifier,
+        'https://localhost/auth/callback',
+        'facebook',
+        'es',
+      );
+    });
+
+    it('calls onSuccess after successful flow', async () => {
+      setupMocks();
+      const onSuccess = jest.fn();
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(onSuccess);
+      await initiate('google');
+
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears sessionStorage after successful popup flow', async () => {
+      setupMocks();
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+
+      expect(storage.has(OAUTH_STORAGE_KEY)).toBe(false);
+    });
+  });
+
+  describe('sessionStorage persistence (web redirect flow)', () => {
+    it('persists PKCE data before opening auth session', async () => {
+      let storedValue: string | null = null;
+
+      (createURL as jest.Mock).mockReturnValue(
+        'https://localhost/auth/callback',
+      );
+      mockGetOAuthSignInUrl.mockResolvedValue({
+        url: 'https://cognito.example.com/oauth2/authorize?...',
+        pkce: DEFAULT_PKCE,
+      });
+
+      // Capture sessionStorage at the moment openAuthSessionAsync is called
+      (openAuthSessionAsync as jest.Mock).mockImplementation(async () => {
+        storedValue = storage.get(OAUTH_STORAGE_KEY) ?? null;
+        return { type: 'cancel' };
+      });
+
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+
+      expect(storedValue).not.toBeNull();
+      const parsed = JSON.parse(storedValue!);
+      expect(parsed).toEqual({
+        codeVerifier: DEFAULT_PKCE.codeVerifier,
+        state: DEFAULT_PKCE.state,
+        provider: 'google',
+        redirectUri: 'https://localhost/auth/callback',
+      });
+    });
+  });
+
+  describe('user cancellation', () => {
+    it('does not call handleOAuthCallback when user cancels', async () => {
+      setupMocks({ authSessionResult: { type: 'cancel' } });
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+
+      expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
+    });
+
+    it('does not call onSuccess when user dismisses', async () => {
+      setupMocks({ authSessionResult: { type: 'dismiss' } });
+      const onSuccess = jest.fn();
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(onSuccess);
+      await initiate('google');
+
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('state validation (CSRF protection)', () => {
+    it('sets error on state mismatch', async () => {
+      setupMocks({
+        authSessionResult: {
+          type: 'success',
+          url: makeSuccessUrl('code-123', 'wrong-state'),
+        },
+      });
+
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+      const state = getHookState(baseIndex);
+
+      expect(state.error).toBe('OAuth state mismatch — possible CSRF attempt');
+      expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('missing authorization code', () => {
+    it('sets error when callback URL has no code parameter', async () => {
+      const urlWithoutCode = 'https://localhost/auth/callback?state=state-xyz';
+      setupMocks({
+        authSessionResult: { type: 'success', url: urlWithoutCode },
+      });
+
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+      const state = getHookState(baseIndex);
+
+      expect(state.error).toBe('Missing authorization code in callback');
+    });
+  });
+
+  describe('error handling', () => {
+    it('captures getOAuthSignInUrl errors', async () => {
+      (createURL as jest.Mock).mockReturnValue(
+        'https://localhost/auth/callback',
+      );
+      mockGetOAuthSignInUrl.mockRejectedValue(new Error('Network failure'));
+
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+      const state = getHookState(baseIndex);
+
+      expect(state.error).toBe('Network failure');
+    });
+
+    it('captures handleOAuthCallback errors', async () => {
+      setupMocks();
+      mockHandleOAuthCallback.mockRejectedValue(
+        new Error('Token exchange failed'),
+      );
+
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+      const state = getHookState(baseIndex);
+
+      expect(state.error).toBe('Token exchange failed');
+    });
+
+    it('clears sessionStorage on error', async () => {
+      setupMocks();
+      mockHandleOAuthCallback.mockRejectedValue(new Error('fail'));
+
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+
+      expect(storage.has(OAUTH_STORAGE_KEY)).toBe(false);
+    });
+
+    it('uses fallback message for non-Error throws', async () => {
+      (createURL as jest.Mock).mockReturnValue(
+        'https://localhost/auth/callback',
+      );
+      mockGetOAuthSignInUrl.mockRejectedValue('string error');
+
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+      const state = getHookState(baseIndex);
+
+      expect(state.error).toBe('Social sign in failed');
+    });
+  });
+
+  describe('loading state', () => {
+    it('is true during initiate and false after', async () => {
+      let loadingDuringCall = false;
+
+      (createURL as jest.Mock).mockReturnValue(
+        'https://localhost/auth/callback',
+      );
+      mockGetOAuthSignInUrl.mockImplementation(async () => {
+        const s = getHookState(baseIndex);
+        loadingDuringCall = s.loading;
+        return {
+          url: 'https://cognito.example.com/oauth2/authorize?...',
+          pkce: DEFAULT_PKCE,
+        };
+      });
+      (openAuthSessionAsync as jest.Mock).mockResolvedValue({ type: 'cancel' });
+
+      baseIndex = stateCounter;
+      const { initiate } = mod.useSocialSignIn(jest.fn());
+      await initiate('google');
+      const state = getHookState(baseIndex);
+
+      expect(loadingDuringCall).toBe(true);
+      expect(state.loading).toBe(false);
+    });
+  });
+
+  describe('OAUTH_STORAGE_KEY constant', () => {
+    it('is exported and has expected value', () => {
+      expect(OAUTH_STORAGE_KEY).toBe('_oauth_pending');
+    });
   });
 });

--- a/client/packages/features/auth/src/presentation/hooks/use-social-sign-in.ts
+++ b/client/packages/features/auth/src/presentation/hooks/use-social-sign-in.ts
@@ -1,0 +1,118 @@
+import { useCallback, useState } from 'react';
+import { createURL } from 'expo-linking';
+import { openAuthSessionAsync } from 'expo-web-browser';
+
+import type { SocialProvider } from '@features/auth/domain/repositories/auth-repository.port';
+import { useAuth } from '@features/auth/presentation/providers/auth-provider';
+import { isWeb } from '@packages/utils/src';
+
+export const OAUTH_STORAGE_KEY = '_oauth_pending';
+
+export interface OAuthPending {
+  codeVerifier: string;
+  state: string;
+  provider: SocialProvider;
+  redirectUri: string;
+}
+
+export interface UseSocialSignInResult {
+  initiate: (provider: SocialProvider) => Promise<void>;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Orchestrates the full social OAuth flow with platform-aware strategy:
+ *
+ * Web:
+ *  - Persists PKCE + provider in sessionStorage before opening the browser session.
+ *  - Uses openAuthSessionAsync (popup on desktop, in-app browser on mobile web).
+ *  - If the popup closes successfully, processes the callback URL in the hook.
+ *  - If the session is handled by the /auth/callback route instead (redirect flow),
+ *    the sessionStorage entry is consumed there and onSuccess is NOT called here.
+ *
+ * Native (iOS / Android):
+ *  - Uses openAuthSessionAsync with the system browser.
+ *  - Processes the deep-link callback URL directly in the hook.
+ *
+ * Facebook profile picture sync is handled transparently inside
+ * AuthProvider.handleOAuthCallback.
+ */
+export function useSocialSignIn(
+  onSuccess: () => void,
+  locale?: string,
+): UseSocialSignInResult {
+  const auth = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const initiate = useCallback(
+    async (provider: SocialProvider) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const redirectUri = createURL('auth/callback');
+        const { url, pkce } = await auth.getOAuthSignInUrl(
+          provider,
+          redirectUri,
+        );
+
+        // Persist PKCE so the /auth/callback route can use it in the redirect flow.
+        if (isWeb() && typeof sessionStorage !== 'undefined') {
+          const pending: OAuthPending = {
+            codeVerifier: pkce.codeVerifier,
+            state: pkce.state,
+            provider,
+            redirectUri,
+          };
+          sessionStorage.setItem(OAUTH_STORAGE_KEY, JSON.stringify(pending));
+        }
+
+        const result = await openAuthSessionAsync(url, redirectUri);
+
+        if (result.type !== 'success') {
+          // User cancelled, dismissed, or the callback page consumed the code
+          // via the redirect flow — not an error in any of these cases.
+          return;
+        }
+
+        // Popup flow: the URL was captured before the callback page could process it.
+        // Clear sessionStorage so the callback page does not re-process it.
+        if (isWeb() && typeof sessionStorage !== 'undefined') {
+          sessionStorage.removeItem(OAUTH_STORAGE_KEY);
+        }
+
+        const params = new URL(result.url).searchParams;
+        const code = params.get('code');
+        const returnedState = params.get('state');
+
+        if (!code) {
+          throw new Error('Missing authorization code in callback');
+        }
+        if (returnedState !== pkce.state) {
+          throw new Error('OAuth state mismatch — possible CSRF attempt');
+        }
+
+        await auth.handleOAuthCallback(
+          code,
+          pkce.codeVerifier,
+          redirectUri,
+          provider,
+          locale,
+        );
+
+        onSuccess();
+      } catch (e) {
+        if (isWeb() && typeof sessionStorage !== 'undefined') {
+          sessionStorage.removeItem(OAUTH_STORAGE_KEY);
+        }
+        setError(e instanceof Error ? e.message : 'Social sign in failed');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [auth, onSuccess, locale],
+  );
+
+  return { initiate, loading, error };
+}

--- a/client/packages/features/auth/src/presentation/pages/login/index.tsx
+++ b/client/packages/features/auth/src/presentation/pages/login/index.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback } from 'react';
 
-import type { SocialProvider } from '@features/ui';
+import { useTranslation } from '@packages/i18n';
 
 import { LoginTemplate } from '@features/auth/presentation/components/shared/templates/login-template';
 import { AuthChallengeType } from '@features/auth/domain/repositories/auth-repository.port';
 import { useAuth } from '@features/auth/presentation/providers/auth-provider';
+import { useSocialSignIn } from '@features/auth/presentation/hooks/use-social-sign-in';
 
 export interface LoginPageProps {
   onForgotPassword: () => void;
@@ -24,6 +25,9 @@ export function LoginPage({
   onMfaSetupRequired,
 }: LoginPageProps) {
   const { signIn, loading, error } = useAuth();
+  const { i18n } = useTranslation();
+  const { initiate: initiateSocialSignIn, loading: socialLoading } =
+    useSocialSignIn(onSignInSuccess, i18n.language);
 
   const handleSignIn = useCallback(
     async (identifier: string, password: string) => {
@@ -57,18 +61,13 @@ export function LoginPage({
     ],
   );
 
-  const handleSocialSignIn = useCallback((_provider: SocialProvider) => {
-    // OAuth flow — Fase 7 (social)
-    console.log('social sign in', _provider);
-  }, []);
-
   return (
     <LoginTemplate
       onSignIn={handleSignIn}
-      onSocialSignIn={handleSocialSignIn}
+      onSocialSignIn={initiateSocialSignIn}
       onForgotPassword={onForgotPassword}
       onSignUp={onSignUp}
-      loading={loading}
+      loading={loading || socialLoading}
       error={error?.message}
     />
   );

--- a/client/packages/features/auth/src/presentation/pages/register/index.tsx
+++ b/client/packages/features/auth/src/presentation/pages/register/index.tsx
@@ -1,17 +1,17 @@
 import React, { useCallback, useState } from 'react';
 
-import type { SocialProvider } from '@features/ui';
-
 import { useTranslation } from '@packages/i18n';
 
 import { RegisterTemplate } from '@features/auth/presentation/components/shared/templates/register-template';
 import type { SignUpDto } from '@features/auth/domain/repositories/auth-repository.port';
 
 import { useAuth } from '@features/auth/presentation/providers/auth-provider';
+import { useSocialSignIn } from '@features/auth/presentation/hooks/use-social-sign-in';
 
 export interface RegisterPageProps {
   onRegisterSuccess: (identifier: string, phone: string) => void;
   onSignIn: () => void;
+  onSocialSignInSuccess?: () => void;
   onPressTerms?: () => void;
   onPressPrivacy?: () => void;
 }
@@ -19,11 +19,14 @@ export interface RegisterPageProps {
 export function RegisterPage({
   onRegisterSuccess,
   onSignIn,
+  onSocialSignInSuccess,
   onPressTerms,
   onPressPrivacy,
 }: RegisterPageProps) {
   const { signUp } = useAuth();
   const { i18n } = useTranslation();
+  const { initiate: initiateSocialSignIn, loading: socialLoading } =
+    useSocialSignIn(onSocialSignInSuccess ?? (() => {}), i18n.language);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
 
@@ -43,19 +46,14 @@ export function RegisterPage({
     [signUp, onRegisterSuccess, i18n],
   );
 
-  const handleSocialSignIn = useCallback((_provider: SocialProvider) => {
-    // OAuth flow — to be implemented in Fase 7
-    console.log('social sign in', _provider);
-  }, []);
-
   return (
     <RegisterTemplate
       onRegister={handleRegister}
       onSignIn={onSignIn}
-      onSocialSignIn={handleSocialSignIn}
+      onSocialSignIn={initiateSocialSignIn}
       onPressTerms={onPressTerms}
       onPressPrivacy={onPressPrivacy}
-      loading={loading}
+      loading={loading || socialLoading}
       error={error}
     />
   );

--- a/client/packages/features/auth/src/presentation/providers/auth-provider.tsx
+++ b/client/packages/features/auth/src/presentation/providers/auth-provider.tsx
@@ -61,7 +61,10 @@ export interface AuthContextValue extends AuthState {
     code: string,
     codeVerifier: string,
     redirectUri: string,
+    provider?: SocialProvider,
+    deviceLocale?: string,
   ) => Promise<void>;
+  updateUserAttribute: (name: string, value: string) => Promise<void>;
   associateSoftwareToken: (
     session: string,
   ) => Promise<{ secretCode: string; qrCodeUrl: string }>;
@@ -343,7 +346,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   );
 
   const handleOAuthCallback = useCallback(
-    async (code: string, codeVerifier: string, redirectUri: string) => {
+    async (
+      code: string,
+      codeVerifier: string,
+      redirectUri: string,
+      provider?: SocialProvider,
+      deviceLocale?: string,
+    ) => {
       setState((prev) => ({ ...prev, loading: true, error: null }));
       try {
         const session = await cognitoAuthRepository.handleOAuthCallback(
@@ -351,7 +360,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           codeVerifier,
           redirectUri,
         );
-        const user = await cognitoAuthRepository.getCurrentUser();
+        let user = await cognitoAuthRepository.getCurrentUser();
+
+        // Sync locale for social sign-in users (non-critical).
+        if (provider && deviceLocale && !user?.locale) {
+          try {
+            await cognitoAuthRepository.updateUserAttribute(
+              'locale',
+              deviceLocale,
+            );
+            // Re-fetch to pick up updated locale
+            user = await cognitoAuthRepository.getCurrentUser();
+          } catch {
+            // Locale sync failed — not critical
+          }
+        }
+
         setState({
           session,
           user,
@@ -370,6 +394,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     },
     [scheduleRefresh],
+  );
+
+  const updateUserAttribute = useCallback(
+    async (name: string, value: string) =>
+      cognitoAuthRepository.updateUserAttribute(name, value),
+    [],
   );
 
   const associateSoftwareToken = useCallback(
@@ -430,6 +460,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     confirmForgotPassword,
     getOAuthSignInUrl,
     handleOAuthCallback,
+    updateUserAttribute,
     associateSoftwareToken,
     verifySoftwareToken,
     clearError,

--- a/client/packages/features/auth/src/presentation/providers/auth-provider.tsx
+++ b/client/packages/features/auth/src/presentation/providers/auth-provider.tsx
@@ -372,7 +372,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             // Re-fetch to pick up updated locale
             user = await cognitoAuthRepository.getCurrentUser();
           } catch {
-            // Locale sync failed — not critical
+            // Non-critical: user enters the app without locale.
+            // It can be set later from the profile screen.
           }
         }
 

--- a/client/packages/i18n/src/locales/en/login/index.ts
+++ b/client/packages/i18n/src/locales/en/login/index.ts
@@ -172,6 +172,12 @@ export const login = {
     back: 'Back to sign in',
   },
 
+  // ── OAuth callback ───────────────────────────────────────────────────────
+  callback: {
+    signInSuccess: 'Sign in successful',
+    signInFailed: 'Sign in failed. Redirecting…',
+  },
+
   // ── Errors ────────────────────────────────────────────────────────────────
   errors: {
     notAuthorized: 'Incorrect email or password.',

--- a/client/packages/i18n/src/locales/es/login/index.ts
+++ b/client/packages/i18n/src/locales/es/login/index.ts
@@ -177,6 +177,12 @@ export const login = {
     back: 'Volver al inicio de sesión',
   },
 
+  // ── OAuth callback ───────────────────────────────────────────────────────
+  callback: {
+    signInSuccess: 'Inicio de sesión exitoso',
+    signInFailed: 'Error al iniciar sesión. Redirigiendo…',
+  },
+
   // ── Errors ────────────────────────────────────────────────────────────────
   errors: {
     notAuthorized: 'Correo o contraseña incorrectos.',

--- a/infra/lib/versions/v1/cognito-stack.ts
+++ b/infra/lib/versions/v1/cognito-stack.ts
@@ -325,6 +325,7 @@ export class CognitoStack extends BaseStack {
         email: ProviderAttribute.GOOGLE_EMAIL,
         givenName: ProviderAttribute.GOOGLE_GIVEN_NAME,
         familyName: ProviderAttribute.GOOGLE_FAMILY_NAME,
+        profilePicture: ProviderAttribute.GOOGLE_PICTURE,
       },
     });
 
@@ -335,6 +336,8 @@ export class CognitoStack extends BaseStack {
       scopes: ['public_profile', 'email'],
       attributeMapping: {
         email: ProviderAttribute.FACEBOOK_EMAIL,
+        givenName: ProviderAttribute.FACEBOOK_FIRST_NAME,
+        familyName: ProviderAttribute.FACEBOOK_LAST_NAME,
       },
     });
 
@@ -350,7 +353,8 @@ export class CognitoStack extends BaseStack {
       scopes: ['name', 'email'],
       attributeMapping: {
         email: ProviderAttribute.APPLE_EMAIL,
-        fullname: ProviderAttribute.APPLE_NAME,
+        givenName: ProviderAttribute.APPLE_FIRST_NAME,
+        familyName: ProviderAttribute.APPLE_LAST_NAME,
       },
     });
 

--- a/infra/lib/versions/v1/cognito-stack.ts
+++ b/infra/lib/versions/v1/cognito-stack.ts
@@ -386,7 +386,13 @@ export class CognitoStack extends BaseStack {
       userPool: this.userPool,
       oAuth: {
         flows: { authorizationCodeGrant: true },
-        scopes: [OAuthScope.OPENID, OAuthScope.EMAIL, OAuthScope.PROFILE],
+        scopes: [
+          OAuthScope.OPENID,
+          OAuthScope.EMAIL,
+          OAuthScope.PROFILE,
+          OAuthScope.PHONE,
+          OAuthScope.COGNITO_ADMIN,
+        ],
         callbackUrls: props.callbackUrls,
         logoutUrls: props.logoutUrls,
       },


### PR DESCRIPTION
## Description

### Scope

This document describes the changes introduced by the `provider-auth-integration` branch compared with `main`, using the `main...provider-auth-integration` diff as the source of truth.

The documentation is intentionally limited to the committed state of the branch and does not include uncommitted local changes detected in the working tree during the review.

### Core changes

#### 1. Federated authentication support in the domain and infrastructure layers

This branch adds formal support for social authentication through Cognito and external identity providers (`Google`, `Facebook`, `Apple`, and `Microsoft`) inside the `@features/auth` package.

The main infrastructure-level changes are:

- Building the OAuth authorization URL with PKCE from `CognitoAuthRepository`.
- Exchanging the `authorization_code` against Cognito's `/oauth2/token` endpoint.
- Explicitly hydrating the `amazon-cognito-identity-js` session after the OAuth callback so that `getCurrentUser()` and `refreshSession()` behave the same way they do after a standard sign-in flow.
- Extending the `AuthRepository` contract with `updateUserAttribute(name, value)` to support post-login profile synchronization.
- Extending the `User` entity with `providerUserId`, populated from Cognito's `identities` attribute.

In practical terms, the branch prepares the authentication repository to treat social sign-in as a first-class authenticated session within the existing auth context.

#### 2. Social sign-in orchestration in the presentation layer

The branch introduces `useSocialSignIn`, exported from `@features/auth`, as the entry point for provider-based authentication.

Its responsibilities are:

- Resolving the `redirectUri` through `expo-linking`.
- Requesting the OAuth URL and PKCE parameters from `AuthProvider`.
- Persisting `codeVerifier`, `state`, provider, and `redirectUri` in `sessionStorage` when running on web.
- Opening the browser session with `openAuthSessionAsync`.
- Validating the provider response, checking `state`, and delegating callback handling to `AuthProvider.handleOAuthCallback`.

The `login` and `register` screens no longer contain social sign-in placeholders and now invoke a real integration flow through this hook.

#### 3. `AuthProvider` updates

`AuthProvider` is updated so the OAuth flow is handled through the same session-management path already used by credential-based authentication:

- `getOAuthSignInUrl` is exposed through the context.
- `handleOAuthCallback` now accepts optional `provider` and `deviceLocale` arguments.
- After the token exchange, the provider restores the session, resolves the current user, and schedules token refresh using the same logic as standard sign-in.
- If a provider-authenticated user does not yet have a `locale`, the provider attempts to synchronize it from the device language in a non-blocking way.
- `updateUserAttribute` is exposed for reuse by other layers.

This keeps a single source of truth for session state inside the global authentication context.

#### 4. Navigation integration in `client/main`

The branch adds the minimum Expo Router changes required to support provider authentication:

- `ROUTES` and `ROUTE_NAMES` now include `authCallback` and `callback`.
- The auth layout avoids redirecting to the dashboard while the active route is `/auth/callback`, preventing the provider return flow from being interrupted.
- The register screen now receives `onSocialSignInSuccess` and redirects to the dashboard when sign-up through a provider succeeds.

#### 5. Cognito and infrastructure changes

`CognitoStack` is updated so the User Pool configuration matches the client-side federated flow:

- `Google` now maps `profilePicture`.
- `Facebook` now maps `givenName` and `familyName`.
- `Apple` stops using an aggregated `fullname` mapping and now maps `givenName` and `familyName` separately.
- The `UserPoolClient` expands OAuth scopes to `openid`, `email`, `profile`, `phone`, and `aws.cognito.signin.user.admin`.

These changes are relevant because the client now relies on additional scopes to operate on the resulting session and to update user attributes after provider sign-in.

#### 6. Test coverage and tooling support

The branch strengthens the test baseline in two areas:

- In `client/packages/features/auth`, Cognito repository tests are expanded to cover the OAuth callback flow, session construction, and null-return scenarios in `getCurrentUser()`.
- In `client/main`, route and screen smoke tests are added for authentication pages that previously had no explicit coverage.

The branch also adds `expo-web-browser` mocks and updates `jest.config.ts` so the new social flow can be tested without depending on Expo runtime behavior.

### Schema changes

There are no database schema changes or migrations in this branch.

There are, however, Cognito identity and session configuration changes:

- New OAuth scopes in the `UserPoolClient`.
- New attribute mappings for external providers.
- New usage of the `identities` attribute to populate `providerUserId`.

### Minor changes

- `@features/auth` now exports `useSocialSignIn` and its return type.
- OAuth callback copy is added to `i18n` for both `en` and `es`.
- `.github/workflows/deploy-main-amplify.yml` expands `deploy_paths` to include `client/packages`, preventing shared auth package changes from being excluded from the deployment trigger criteria.

## Functional flow

### Social sign-in

1. The login or register screen invokes `useSocialSignIn`.
2. The hook requests the OAuth URL and PKCE data from the auth provider.
3. The external authentication session is opened with `openAuthSessionAsync`.
4. If the provider returns a success URL to the client, the hook validates `code` and `state`.
5. `AuthProvider.handleOAuthCallback` exchanges the code for Cognito tokens.
6. The Cognito SDK session is injected, the current user is resolved, and token refresh is scheduled.
7. The UI executes the success callback and navigates to the expected destination.

### User attributes

After provider sign-in:

- The user object is reconstructed from normalized Cognito attributes.
- If `locale` is missing and the flow provides a device language, the application attempts to persist it.
- `providerUserId` becomes available for provider-specific traceability or downstream integrations.

## Current status and limitations

The branch resolves most of the social authentication work in the repository, provider, screens, infrastructure, and baseline test setup. That said, two points are important in the current committed state compared with `main`:

1. The callback screen [client/main/app/auth/callback/index.tsx](/Users/miguelangelgutierrezmaya/Projects/migudev/financial-management/client/main/app/auth/callback/index.tsx) that exists in the branch history is still a placeholder. The route exists, the auth layout preserves it, and the hook stores PKCE data for eventual callback consumption, but the screen itself does not yet complete the OAuth exchange.
2. `useSocialSignIn` maintains its own local error state, while the updated screens only surface the global `useAuth` error or their own local registration state. As a result, failures that happen before `AuthProvider` captures them may not be shown in the final UI.

In other words, the branch enables the main federated sign-in path, but it does not yet leave behind a fully self-sufficient web callback strategy based on `/auth/callback`.

## How to Test

### Manual validation

1. Deploy the Cognito infrastructure with the updated provider mappings and OAuth scopes.
2. Verify that Cognito `callbackUrls` include the URL generated by `createURL('auth/callback')` for each target environment.
3. From login, sign in with each enabled provider and confirm:
   - browser or popup launch,
   - successful return to the client,
   - session creation,
   - current user resolution,
   - redirect to the dashboard.
4. Repeat the flow from the register screen and verify that `onSocialSignInSuccess` redirects to the dashboard.
5. Confirm that a provider-authenticated user without `locale` ends up with that attribute synchronized when the provider receives `deviceLocale`.
6. Validate that `getCurrentUser()` and `refreshSession()` continue to work after social login, especially after reloading the application.
7. On web, test the direct return case to `/auth/callback` and verify the current branch behavior: the screen does not complete the flow on its own yet and falls back to login.

### Automated coverage added in the branch

- Cognito repository tests for `handleOAuthCallback`.
- Regression coverage for `getCurrentUser()` when the session or user attributes are invalid.
- `expo-web-browser` mocks for both `client/main` and `@features/auth`.
- Expo Router smoke tests for authentication routes.

## Checklist

- [x] The branch introduces structural support for provider sign-in in both client and infrastructure.
- [x] The `@features/auth` package exposes the API required to initiate and complete the OAuth flow.
- [x] Tests and mocks were added to support the integration baseline.
- [x] There are no database changes.
- [ ] The `/auth/callback` flow is fully completed within the current committed branch history.
