### PR TITLE
Adding workflow support for infra deploy

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,0 +1,220 @@
+# Deploy infrastructure (CDK) to AWS for staging and production environments.
+#
+# Automatic deploy fires after Integration Tests pass on main when changes
+# are detected in relevant paths.
+# Release and manual triggers always deploy regardless of changed paths.
+#
+# Environment resolution (single source of truth: setup job):
+#   staging    — Integration Tests pass on main  OR  pre-release
+#   production — published release (non-pre-release)
+#   manual     — environment chosen via workflow_dispatch input
+#
+# Authentication: OIDC — no static AWS keys required.
+# The IAM role is assumed via GitHub's OIDC provider (id-token: write).
+#
+# Configure per environment in GitHub Settings → Environments:
+#
+#   Required secrets:
+#     DEPLOY_ROLE_ARN        — ARN of the IAM role with CDK deploy permissions
+#     DATABASE_URL           — Write connection string (Supabase pooler)
+#     DATABASE_READONLY_URL  — Read-only connection string
+#     GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, FACEBOOK_APP_ID, FACEBOOK_APP_SECRET
+#     APPLE_CLIENT_ID, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY
+#     MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET, MICROSOFT_TENANT_ID
+#     ACCESS_TOKEN_NAME
+#
+#   Required variables:
+#     AWS_REGION, PROJECT_PREFIX, STAGE, ALLOWED_ORIGINS
+#     AMPLIFY_DEFAULT_BRANCH, AMPLIFY_STAGE, AMPLIFY_REPOSITORY
+#     AMPLIFY_ENABLE_AUTO_BUILD, AMPLIFY_CLIENT_MAIN_ROOT
+#     ASSETS_BUCKET_URL, ASSETS_BUCKET_PREFIX, APPLICATION_URL
+#     COGNITO_DOMAIN_PREFIX, COGNITO_CALLBACK_URLS, COGNITO_LOGOUT_URLS
+#     COGNITO_REMOVAL_PROTECT, COGNITO_EMAILS_PREFIX
+#     SES_FROM_EMAIL, SES_REPLY_TO, SNS_MONTHLY_SPEND_LIMIT, SMS_BLOCKED_COUNTRIES
+
+name: Deploy Infrastructure
+
+on:
+  workflow_run:
+    workflows: ['Integration Tests']
+    types: [completed]
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      dry_run:
+        description: 'Simulate the deploy without running CDK (for testing)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    infra-deploy-${{
+      (github.event_name == 'workflow_run' ||
+       (github.event_name == 'release' && github.event.release.prerelease == true))
+      && 'staging'
+      || inputs.environment
+      || 'production'
+    }}
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    name: ⚙️ Resolve environment & verify CI
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      env_name: ${{ steps.resolve.outputs.env_name }}
+      should_deploy: ${{ steps.resolve.outputs.should_deploy }}
+    steps:
+      - name: 📥 Checkout actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: ⚙️ Resolve environment and check CI
+        id: resolve
+        uses: ./.github/actions/resolve_deploy_env
+        with:
+          deploy_paths: '^(infra/|services/|packages/|\.github/workflows/deploy-infra\.yml)'
+
+  deploy:
+    name: 🚀 CDK Deploy (${{ needs.setup.outputs.env_name }})
+    needs: [setup]
+    if: needs.setup.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: ${{ needs.setup.outputs.env_name }}
+
+    env:
+      DEPLOY_ROLE_ARN: ${{ secrets.DEPLOY_ROLE_ARN }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      DEPLOY_ENV: ${{ needs.setup.outputs.env_name }}
+      # CDK env vars
+      PROJECT_PREFIX: ${{ vars.PROJECT_PREFIX }}
+      STAGE: ${{ vars.STAGE }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DATABASE_READONLY_URL: ${{ secrets.DATABASE_READONLY_URL }}
+      ALLOWED_ORIGINS: ${{ vars.ALLOWED_ORIGINS }}
+      # Amplify
+      AMPLIFY_DEFAULT_BRANCH: ${{ vars.AMPLIFY_DEFAULT_BRANCH }}
+      AMPLIFY_STAGE: ${{ vars.AMPLIFY_STAGE }}
+      AMPLIFY_REPOSITORY: ${{ vars.AMPLIFY_REPOSITORY }}
+      AMPLIFY_ENABLE_AUTO_BUILD: ${{ vars.AMPLIFY_ENABLE_AUTO_BUILD }}
+      AMPLIFY_CLIENT_MAIN_ROOT: ${{ vars.AMPLIFY_CLIENT_MAIN_ROOT }}
+      ACCESS_TOKEN_NAME: ${{ secrets.ACCESS_TOKEN_NAME }}
+      ASSETS_BUCKET_URL: ${{ vars.ASSETS_BUCKET_URL }}
+      ASSETS_BUCKET_PREFIX: ${{ vars.ASSETS_BUCKET_PREFIX }}
+      APPLICATION_URL: ${{ vars.APPLICATION_URL }}
+      # Cognito
+      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      FACEBOOK_APP_ID: ${{ secrets.FACEBOOK_APP_ID }}
+      FACEBOOK_APP_SECRET: ${{ secrets.FACEBOOK_APP_SECRET }}
+      APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+      APPLE_PRIVATE_KEY: ${{ secrets.APPLE_PRIVATE_KEY }}
+      MICROSOFT_CLIENT_ID: ${{ secrets.MICROSOFT_CLIENT_ID }}
+      MICROSOFT_CLIENT_SECRET: ${{ secrets.MICROSOFT_CLIENT_SECRET }}
+      MICROSOFT_TENANT_ID: ${{ secrets.MICROSOFT_TENANT_ID }}
+      COGNITO_DOMAIN_PREFIX: ${{ vars.COGNITO_DOMAIN_PREFIX }}
+      COGNITO_CALLBACK_URLS: ${{ vars.COGNITO_CALLBACK_URLS }}
+      COGNITO_LOGOUT_URLS: ${{ vars.COGNITO_LOGOUT_URLS }}
+      COGNITO_REMOVAL_PROTECT: ${{ vars.COGNITO_REMOVAL_PROTECT }}
+      COGNITO_EMAILS_PREFIX: ${{ vars.COGNITO_EMAILS_PREFIX }}
+      SES_FROM_EMAIL: ${{ vars.SES_FROM_EMAIL }}
+      SES_REPLY_TO: ${{ vars.SES_REPLY_TO }}
+      SNS_MONTHLY_SPEND_LIMIT: ${{ vars.SNS_MONTHLY_SPEND_LIMIT }}
+      SMS_BLOCKED_COUNTRIES: ${{ vars.SMS_BLOCKED_COUNTRIES }}
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🔧 Configure pnpm and Node.js
+        uses: ./.github/actions/configure_pnpm
+
+      - name: 📌 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: ✅ Validate required configuration
+        shell: bash
+        run: |
+          missing=()
+          [[ -z "$DEPLOY_ROLE_ARN" ]] && missing+=("DEPLOY_ROLE_ARN")
+          [[ -z "$PROJECT_PREFIX" ]] && missing+=("PROJECT_PREFIX")
+          [[ -z "$DATABASE_URL" ]] && missing+=("DATABASE_URL")
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Missing required secrets/variables: ${missing[*]}"
+            exit 1
+          fi
+          echo "✅ All required secrets and variables are set."
+
+      - name: 🔐 Assume deployment role
+        uses: ./.github/actions/assume_role
+        with:
+          role-arn: ${{ env.DEPLOY_ROLE_ARN }}
+          region: ${{ env.AWS_REGION }}
+
+      - name: 🏗️ CDK Deploy
+        shell: bash
+        run: |
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "::notice::Dry run — running cdk diff instead of deploy"
+            pnpm --filter @infra exec -- npx cdk diff --all
+          else
+            pnpm --filter @infra exec -- npx cdk deploy --all --require-approval never --outputs-file cdk-outputs.json
+          fi
+
+      - name: 📤 Upload CDK outputs
+        if: success() && env.DRY_RUN != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdk-outputs-${{ env.DEPLOY_ENV }}
+          path: infra/cdk-outputs.json
+          retention-days: 5
+
+      - name: 📋 Job summary
+        if: always()
+        shell: bash
+        run: |
+          RELEASE="${{ github.event.release.tag_name || 'n/a' }}"
+          TRIGGER="${{ github.event_name }}"
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            TITLE="🏗️ Infrastructure deploy (dry run)"
+          else
+            TITLE="🏗️ Infrastructure deployed"
+          fi
+
+          {
+            echo "### $TITLE"
+            echo ""
+            echo "| Item | Value |"
+            echo "|------|-------|"
+            echo "| Environment | \`$DEPLOY_ENV\` |"
+            echo "| Trigger | \`$TRIGGER\` |"
+            echo "| Release | $RELEASE |"
+            echo "| Region | \`$AWS_REGION\` |"
+            echo "| Project | \`$PROJECT_PREFIX\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -162,8 +162,11 @@ jobs:
         run: |
           missing=()
           [[ -z "$DEPLOY_ROLE_ARN" ]] && missing+=("DEPLOY_ROLE_ARN")
+          [[ -z "$AWS_REGION" ]] && missing+=("AWS_REGION")
           [[ -z "$PROJECT_PREFIX" ]] && missing+=("PROJECT_PREFIX")
+          [[ -z "$STAGE" ]] && missing+=("STAGE")
           [[ -z "$DATABASE_URL" ]] && missing+=("DATABASE_URL")
+          [[ -z "$ALLOWED_ORIGINS" ]] && missing+=("ALLOWED_ORIGINS")
           if [[ ${#missing[@]} -gt 0 ]]; then
             echo "::error::Missing required secrets/variables: ${missing[*]}"
             exit 1

--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -1,0 +1,182 @@
+# Publish API documentation to S3 after infrastructure deploy.
+#
+# Exports the OpenAPI spec from API Gateway and uploads it alongside
+# Swagger UI to the files.migudev.com S3 bucket for public access.
+#
+# Trigger: fires automatically after Deploy Infrastructure succeeds.
+#
+# URLs:
+#   staging:    https://files.migudev.com/api-docs/staging/index.html
+#   production: https://files.migudev.com/api-docs/production/index.html
+
+name: Publish API Docs
+
+on:
+  workflow_run:
+    workflows: ['Deploy Infrastructure']
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    api-docs-${{
+      (github.event_name == 'workflow_run' ||
+       (github.event_name == 'release' && github.event.release.prerelease == true))
+      && 'staging'
+      || 'production'
+    }}
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    name: ⚙️ Resolve environment
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      env_name: ${{ steps.resolve.outputs.env_name }}
+      should_deploy: ${{ steps.resolve.outputs.should_deploy }}
+    steps:
+      - name: 📥 Checkout actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: ⚙️ Resolve environment
+        id: resolve
+        uses: ./.github/actions/resolve_deploy_env
+        with:
+          deploy_paths: '^(infra/|services/|packages/)'
+
+  publish:
+    name: 📚 Publish API Docs (${{ needs.setup.outputs.env_name }})
+    needs: [setup]
+    if: needs.setup.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    environment:
+      name: ${{ needs.setup.outputs.env_name }}
+
+    env:
+      DEPLOY_ROLE_ARN: ${{ secrets.DEPLOY_ROLE_ARN }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      PROJECT_PREFIX: ${{ vars.PROJECT_PREFIX }}
+      STAGE: ${{ vars.STAGE }}
+      API_DOCS_BUCKET: ${{ vars.API_DOCS_BUCKET }}
+      API_DOCS_PREFIX: ${{ vars.API_DOCS_PREFIX }}
+      DEPLOY_ENV: ${{ needs.setup.outputs.env_name }}
+
+    steps:
+      - name: 📥 Checkout actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: 📦 Download CDK outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: cdk-outputs-${{ env.DEPLOY_ENV }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔐 Assume deployment role
+        uses: ./.github/actions/assume_role
+        with:
+          role-arn: ${{ env.DEPLOY_ROLE_ARN }}
+          region: ${{ env.AWS_REGION }}
+
+      - name: 🔍 Extract API Gateway ID from CDK outputs
+        id: api
+        shell: bash
+        run: |
+          API_URL=$(jq -r 'to_entries[].value | to_entries[] | select(.key | contains("ApiUrl")) | .value' cdk-outputs.json | head -1)
+          API_ID=$(echo "$API_URL" | grep -oP '[a-z0-9]+(?=\.execute-api)')
+          echo "api_id=$API_ID" >> "$GITHUB_OUTPUT"
+          echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
+          echo "API Gateway ID: $API_ID"
+          echo "API URL: $API_URL"
+
+      - name: 📤 Export OpenAPI spec
+        shell: bash
+        run: |
+          mkdir -p api-docs
+          aws apigateway get-export \
+            --rest-api-id "${{ steps.api.outputs.api_id }}" \
+            --stage-name "$STAGE" \
+            --export-type oas30 \
+            --accepts application/json \
+            api-docs/openapi.json
+          echo "OpenAPI spec exported successfully"
+
+      - name: 🎨 Download Swagger UI
+        shell: bash
+        run: |
+          SWAGGER_VERSION="5.21.0"
+          curl -sL "https://unpkg.com/swagger-ui-dist@${SWAGGER_VERSION}/swagger-ui-bundle.js" -o api-docs/swagger-ui-bundle.js
+          curl -sL "https://unpkg.com/swagger-ui-dist@${SWAGGER_VERSION}/swagger-ui.css" -o api-docs/swagger-ui.css
+          echo "Swagger UI v${SWAGGER_VERSION} downloaded"
+
+      - name: 📝 Generate index.html
+        shell: bash
+        run: |
+          cat > api-docs/index.html << 'HTMLEOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Financial Management API</title>
+            <link rel="stylesheet" href="swagger-ui.css">
+          </head>
+          <body>
+            <div id="swagger-ui"></div>
+            <script src="swagger-ui-bundle.js"></script>
+            <script>
+              SwaggerUIBundle({
+                url: 'openapi.json',
+                dom_id: '#swagger-ui',
+                deepLinking: true,
+                presets: [SwaggerUIBundle.presets.apis],
+                layout: 'BaseLayout',
+              });
+            </script>
+          </body>
+          </html>
+          HTMLEOF
+
+      - name: ☁️ Upload to S3
+        shell: bash
+        run: |
+          aws s3 sync api-docs/ "s3://${API_DOCS_BUCKET}/${API_DOCS_PREFIX}/" \
+            --delete \
+            --cache-control "public, max-age=300"
+          echo "Uploaded to s3://${API_DOCS_BUCKET}/${API_DOCS_PREFIX}/"
+
+      - name: 📋 Job summary
+        if: always()
+        shell: bash
+        run: |
+          DOCS_URL="https://${API_DOCS_BUCKET}/${API_DOCS_PREFIX}/index.html"
+          API_URL="${{ steps.api.outputs.api_url }}"
+
+          {
+            echo "### 📚 API Documentation Published"
+            echo ""
+            echo "| Item | Value |"
+            echo "|------|-------|"
+            echo "| Environment | \`$DEPLOY_ENV\` |"
+            echo "| API Gateway | \`${{ steps.api.outputs.api_id }}\` |"
+            echo "| API URL | $API_URL |"
+            echo "| Docs URL | [$DOCS_URL]($DOCS_URL) |"
+            echo "| Region | \`$AWS_REGION\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -20,13 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: >-
-    api-docs-${{
-      (github.event_name == 'workflow_run' ||
-       (github.event_name == 'release' && github.event.release.prerelease == true))
-      && 'staging'
-      || 'production'
-    }}
+  group: api-docs-${{ github.event.workflow_run.id }}
   cancel-in-progress: false
 
 jobs:
@@ -47,11 +41,27 @@ jobs:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
-      - name: ⚙️ Resolve environment
+      - name: ⚙️ Resolve environment from deploy artifacts
         id: resolve
-        uses: ./.github/actions/resolve_deploy_env
-        with:
-          deploy_paths: '^(infra/|services/|packages/)'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          ARTIFACTS=$(curl -sS \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts")
+
+          if echo "$ARTIFACTS" | jq -e '.artifacts[] | select(.name == "cdk-outputs-production")' >/dev/null 2>&1; then
+            ENV_NAME="production"
+          else
+            ENV_NAME="staging"
+          fi
+
+          echo "env_name=${ENV_NAME}" >> "$GITHUB_OUTPUT"
+          echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          echo "Resolved environment: ${ENV_NAME}"
 
   publish:
     name: 📚 Publish API Docs (${{ needs.setup.outputs.env_name }})
@@ -86,6 +96,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cdk-outputs-${{ env.DEPLOY_ENV }}
+          path: .
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -99,7 +110,9 @@ jobs:
         id: api
         shell: bash
         run: |
-          API_URL=$(jq -r 'to_entries[].value | to_entries[] | select(.key | contains("ApiUrl")) | .value' cdk-outputs.json | head -1)
+          CDK_FILE=$(find . -name "cdk-outputs.json" -type f | head -1)
+          echo "Found CDK outputs at: $CDK_FILE"
+          API_URL=$(jq -r 'to_entries[].value | to_entries[] | select(.key | contains("ApiUrl")) | .value' "$CDK_FILE" | head -1)
           API_ID=$(echo "$API_URL" | grep -oP '[a-z0-9]+(?=\.execute-api)')
           echo "api_id=$API_ID" >> "$GITHUB_OUTPUT"
           echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
@@ -122,8 +135,8 @@ jobs:
         shell: bash
         run: |
           SWAGGER_VERSION="5.21.0"
-          curl -sL "https://unpkg.com/swagger-ui-dist@${SWAGGER_VERSION}/swagger-ui-bundle.js" -o api-docs/swagger-ui-bundle.js
-          curl -sL "https://unpkg.com/swagger-ui-dist@${SWAGGER_VERSION}/swagger-ui.css" -o api-docs/swagger-ui.css
+          curl -fsSL "https://unpkg.com/swagger-ui-dist@${SWAGGER_VERSION}/swagger-ui-bundle.js" -o api-docs/swagger-ui-bundle.js
+          curl -fsSL "https://unpkg.com/swagger-ui-dist@${SWAGGER_VERSION}/swagger-ui.css" -o api-docs/swagger-ui.css
           echo "Swagger UI v${SWAGGER_VERSION} downloaded"
 
       - name: 📝 Generate index.html

--- a/config/.env.defaults
+++ b/config/.env.defaults
@@ -57,11 +57,6 @@ SES_FROM_EMAIL="noreply@example.com"
 SES_REPLY_TO="support@example.com"
 
 #
-# ── Aurora DSQL ───────────────────────────────────
-#
-DSQL_DELETION_PROTECTION="false"
-
-#
 # ── Assets url ──────────────────────────
 #
 ASSETS_URL="http://localhost:3000"


### PR DESCRIPTION
## Description

### Core changes

- Adds a new `Deploy Infrastructure` workflow to handle CDK deployments for `staging` and `production` from three entry points: successful `Integration Tests` runs, published releases, and manual dispatches.
- Centralizes environment resolution and deploy gating through the shared `resolve_deploy_env` action so automated deployments only proceed when CI passed and relevant paths changed.
- Configures the deploy job to validate required configuration, assume the AWS deployment role through OIDC, support `dry_run` executions with `cdk diff`, and publish CDK outputs as an artifact for downstream workflows.
- Adds a new `Publish API Docs` workflow that runs after a successful infrastructure deployment, exports the OpenAPI definition from API Gateway, bundles Swagger UI assets, and syncs the generated documentation to S3 per environment.

### Schema changes

- No database schema changes.

### Minor changes

- Removes `DSQL_DELETION_PROTECTION` from `config/.env.defaults` because it is no longer part of the active infrastructure configuration.
- Adds per-environment workflow concurrency and job summaries to make deployment runs easier to track and prevent overlapping executions for the same target environment.

## Screenshots/Recordings

Not applicable.

## How to Test

<!-- Provide step-by-step instructions on how to test this PR manually. Include expected results where applicable. -->

1. Trigger the `Deploy Infrastructure` workflow manually from GitHub Actions with `environment=staging` and `dry_run=true`.
   Expected result: the workflow resolves `staging`, validates the required variables and secrets, assumes the AWS role successfully, and runs `cdk diff` instead of `cdk deploy`.
2. Trigger the same workflow again with `environment=staging` and `dry_run=false` in an environment where the required GitHub environment variables and secrets are already configured.
   Expected result: the deployment completes successfully and uploads the `cdk-outputs-staging` artifact.
3. Verify that `Publish API Docs` starts automatically after the infrastructure workflow finishes successfully.
   Expected result: the workflow downloads the `cdk-outputs-staging` artifact, extracts the API Gateway ID, exports `openapi.json`, and uploads the generated Swagger UI files to the configured S3 prefix.
4. Open the published documentation URL from the workflow summary.
   Expected result: the Swagger UI loads correctly and renders the API definition for the deployed environment.
5. Validate the automatic deploy guard by running the `Integration Tests` workflow on a commit without changes under `infra/`, `services/`, `packages/`, or `.github/workflows/deploy-infra.yml`.
   Expected result: the setup job resolves the environment but marks `should_deploy=false`, so the deploy job is skipped.

## Checklist

- [x] The PR description includes clear instructions on how to test the implementation manually.

##### Added Tests?

- [ ] yes
  - [ ] Verified that this PR is not creating duplicate use cases
  - [ ] All edge cases described in the acceptance criteria are covered, and tests have clear and descriptive names
- [x] no, because they aren't needed
- [ ] no, because I need help

_Override these when needed._

<!-- START OVERRIDES -->

```sh

```

<!-- END OVERRIDES -->
