### PR TITLE
Config enhacements

### DIFF
--- a/client/packages/features/dashboard/src/presentation/components/shared/molecules/expense-card-skeleton/index.test.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/molecules/expense-card-skeleton/index.test.tsx
@@ -1,0 +1,11 @@
+import { ExpenseCardSkeleton } from '.';
+
+describe('ExpenseCardSkeleton', () => {
+  it('exports a function component', () => {
+    expect(typeof ExpenseCardSkeleton).toBe('function');
+  });
+
+  it('has the expected name', () => {
+    expect(ExpenseCardSkeleton.name).toBe('ExpenseCardSkeleton');
+  });
+});

--- a/client/packages/features/dashboard/src/presentation/components/shared/molecules/expense-card-skeleton/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/molecules/expense-card-skeleton/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Skeleton } from '@features/ui/components';
+
+export function ExpenseCardSkeleton() {
+  return (
+    <View className="bg-white dark:bg-slate-800 rounded-xl p-4 mb-3 border border-slate-100 dark:border-slate-700">
+      <View className="flex-row items-start justify-between">
+        <View className="flex-1 mr-3">
+          <Skeleton width="60%" height={18} borderRadius={4} />
+          <View className="flex-row items-center gap-2 mt-2">
+            <Skeleton width={70} height={22} borderRadius={12} />
+            <Skeleton width={80} height={22} borderRadius={12} />
+            <Skeleton width={65} height={14} borderRadius={4} />
+          </View>
+        </View>
+        <View className="items-end">
+          <Skeleton width={90} height={18} borderRadius={4} />
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/client/packages/features/dashboard/src/presentation/components/web/organisms/expense-list/index.test.ts
+++ b/client/packages/features/dashboard/src/presentation/components/web/organisms/expense-list/index.test.ts
@@ -35,11 +35,11 @@ describe('ExpenseList component', () => {
   });
 
   describe('rendering logic', () => {
-    it('shows loading spinner when loading and expenses is empty', () => {
+    it('shows skeleton loader when loading and expenses is empty', () => {
       const loading = true;
       const expenses: unknown[] = [];
-      const showSpinner = loading && expenses.length === 0;
-      expect(showSpinner).toBe(true);
+      const showSkeleton = loading && expenses.length === 0;
+      expect(showSkeleton).toBe(true);
     });
 
     it('shows empty state when not loading and expenses is empty', () => {
@@ -55,11 +55,11 @@ describe('ExpenseList component', () => {
       expect(showList).toBe(true);
     });
 
-    it('does not show spinner when loading but expenses exist', () => {
+    it('does not show skeleton when loading but expenses exist', () => {
       const loading = true;
       const expenses = [{ id: '1' }];
-      const showSpinner = loading && expenses.length === 0;
-      expect(showSpinner).toBe(false);
+      const showSkeleton = loading && expenses.length === 0;
+      expect(showSkeleton).toBe(false);
     });
   });
 

--- a/client/packages/features/dashboard/src/presentation/components/web/organisms/expense-list/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/web/organisms/expense-list/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FlatList } from 'react-native';
+import { FlatList, View } from 'react-native';
 import type {
   Expense,
   ExpenseType,
@@ -8,6 +8,9 @@ import type {
 } from '@packages/models/expenses';
 import { LoadingSpinner, EmptyState } from '@features/ui/components';
 import { ExpenseCard } from '@features/dashboard/presentation/components/shared/molecules/expense-card';
+import { ExpenseCardSkeleton } from '@features/dashboard/presentation/components/shared/molecules/expense-card-skeleton';
+
+const SKELETON_COUNT = 5;
 
 interface ExpenseListProps {
   expenses: Expense[];
@@ -39,7 +42,13 @@ export function ExpenseList({
   emptyDescription,
 }: ExpenseListProps) {
   if (loading && expenses.length === 0) {
-    return <LoadingSpinner fullScreen />;
+    return (
+      <View className="flex-1" style={{ paddingBottom: 24 }}>
+        {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+          <ExpenseCardSkeleton key={i} />
+        ))}
+      </View>
+    );
   }
 
   if (!loading && expenses.length === 0) {

--- a/client/packages/features/ui/src/components/index.ts
+++ b/client/packages/features/ui/src/components/index.ts
@@ -22,6 +22,8 @@ export { Badge } from './shared/atoms/badge';
 export { EmptyState } from './shared/atoms/empty-state';
 export { LoadingSpinner } from './shared/atoms/loading-spinner';
 export { SelectorField } from './shared/atoms/selector-field';
+export { Skeleton } from './shared/atoms/skeleton';
+export type { SkeletonProps } from './shared/atoms/skeleton';
 export type { SelectorFieldProps } from './shared/atoms/selector-field';
 export { SocialAuthButton } from './shared/molecules/social-auth-button';
 export type { SocialProvider } from './shared/molecules/social-auth-button';

--- a/client/packages/features/ui/src/components/shared/atoms/skeleton/index.test.tsx
+++ b/client/packages/features/ui/src/components/shared/atoms/skeleton/index.test.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from '.';
+
+describe('Skeleton', () => {
+  it('exports a function component', () => {
+    expect(typeof Skeleton).toBe('function');
+  });
+
+  it('has the expected name', () => {
+    expect(Skeleton.name).toBe('Skeleton');
+  });
+});

--- a/client/packages/features/ui/src/components/shared/atoms/skeleton/index.tsx
+++ b/client/packages/features/ui/src/components/shared/atoms/skeleton/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { DimensionValue } from 'react-native';
+import { View } from 'react-native';
+
+export interface SkeletonProps {
+  width?: DimensionValue;
+  height?: number;
+  borderRadius?: number;
+  circle?: boolean;
+  className?: string;
+}
+
+export function Skeleton({
+  width = '100%',
+  height = 16,
+  borderRadius = 6,
+  circle = false,
+  className,
+}: SkeletonProps) {
+  return (
+    <View className={className}>
+      <View
+        style={{
+          width: circle ? height : width,
+          height,
+          borderRadius: circle ? height / 2 : borderRadius,
+        }}
+        className="animate-pulse bg-slate-200 dark:bg-slate-700"
+      />
+    </View>
+  );
+}

--- a/config/.env.defaults
+++ b/config/.env.defaults
@@ -72,6 +72,8 @@ ACCESS_TOKEN_NAME="github_token"
 AMPLIFY_ENABLE_AUTO_BUILD="false"
 ASSETS_BUCKET_URL="http://localhost:3000"
 APPLICATION_URL="http://localhost:3000"
+AMPLIFY_CUSTOM_DOMAIN="example.com"
+AMPLIFY_CUSTOM_DOMAIN_PREFIX="dev"
 
 #
 # ── Assets — Storage configuration ──────────────

--- a/infra/lib/versions/v2/amplify-hosting-stack.test.ts
+++ b/infra/lib/versions/v2/amplify-hosting-stack.test.ts
@@ -1,7 +1,7 @@
 import { Construct } from 'constructs';
 import { AmplifyHostingStack } from './amplify-hosting-stack';
 import { importFromVersion } from '@utils/cross-version';
-import { CfnApp, CfnBranch } from 'aws-cdk-lib/aws-amplify';
+import { CfnApp, CfnBranch, CfnDomain } from 'aws-cdk-lib/aws-amplify';
 
 jest.mock('@utils/cross-version', () => ({
   importFromVersion: jest.fn(
@@ -25,6 +25,11 @@ const mockCfnApp = {
 };
 
 const mockCfnBranch = {
+  addDependency: jest.fn(),
+  node: {},
+};
+
+const mockCfnDomain = {
   addDependency: jest.fn(),
   node: {},
 };
@@ -53,6 +58,7 @@ jest.mock('aws-cdk-lib', () => {
 jest.mock('aws-cdk-lib/aws-amplify', () => ({
   CfnApp: jest.fn().mockImplementation(() => mockCfnApp),
   CfnBranch: jest.fn().mockImplementation(() => mockCfnBranch),
+  CfnDomain: jest.fn().mockImplementation(() => mockCfnDomain),
 }));
 
 describe('AmplifyHostingStack', () => {
@@ -248,6 +254,99 @@ describe('AmplifyHostingStack', () => {
       'MainBranch',
       expect.objectContaining({
         branchName: 'develop',
+      }),
+    );
+  });
+
+  test('does not create CfnDomain when customDomain is not provided', () => {
+    const app = { node: { tryGetContext: jest.fn(), children: [] } };
+    (CfnDomain as unknown as jest.Mock).mockClear();
+    new AmplifyHostingStack(
+      app as unknown as Construct,
+      'AmplifyHostingStack',
+      {
+        version: 'v2',
+        stackName: 'AmplifyHosting',
+        description: 'Amplify Hosting for client app',
+        repository: 'https://github.com/org/repo',
+        accessTokenName: 'github-migudev-token',
+        platform: 'WEB',
+        stage: 'DEVELOPMENT',
+        defaultBranchName: 'develop',
+        enableAutoBuild: false,
+        appRoot: 'client/main',
+        assetsBucketUrl: 'https://example.com',
+        applicationUrl: 'https://example.com',
+      },
+    );
+    expect(CfnDomain).not.toHaveBeenCalled();
+  });
+
+  test('creates CfnDomain when customDomain is provided', () => {
+    const app = { node: { tryGetContext: jest.fn(), children: [] } };
+    (CfnDomain as unknown as jest.Mock).mockClear();
+    mockCfnDomain.addDependency.mockClear();
+    new AmplifyHostingStack(
+      app as unknown as Construct,
+      'AmplifyHostingStack',
+      {
+        version: 'v2',
+        stackName: 'AmplifyHosting',
+        description: 'Amplify Hosting for client app',
+        repository: 'https://github.com/org/repo',
+        accessTokenName: 'github-migudev-token',
+        platform: 'WEB',
+        stage: 'PRODUCTION',
+        defaultBranchName: 'main',
+        enableAutoBuild: false,
+        appRoot: 'client/main',
+        assetsBucketUrl: 'https://example.com',
+        applicationUrl: 'https://app.example.com',
+        customDomain: 'app.example.com',
+      },
+    );
+    expect(CfnDomain).toHaveBeenCalledWith(
+      expect.anything(),
+      'CustomDomain',
+      expect.objectContaining({
+        appId: 'mock-app-id',
+        domainName: 'app.example.com',
+        enableAutoSubDomain: false,
+        subDomainSettings: [{ branchName: 'main', prefix: '' }],
+      }),
+    );
+    expect(mockCfnDomain.addDependency).toHaveBeenCalledWith(mockCfnBranch);
+  });
+
+  test('creates CfnDomain with subdomain prefix', () => {
+    const app = { node: { tryGetContext: jest.fn(), children: [] } };
+    (CfnDomain as unknown as jest.Mock).mockClear();
+    new AmplifyHostingStack(
+      app as unknown as Construct,
+      'AmplifyHostingStack',
+      {
+        version: 'v2',
+        stackName: 'AmplifyHosting',
+        description: 'Amplify Hosting for client app',
+        repository: 'https://github.com/org/repo',
+        accessTokenName: 'github-migudev-token',
+        platform: 'WEB',
+        stage: 'DEVELOPMENT',
+        defaultBranchName: 'develop',
+        enableAutoBuild: true,
+        appRoot: 'client/main',
+        assetsBucketUrl: 'https://example.com',
+        applicationUrl: 'https://dev.app.example.com',
+        customDomain: 'app.example.com',
+        customDomainPrefix: 'dev',
+      },
+    );
+    expect(CfnDomain).toHaveBeenCalledWith(
+      expect.anything(),
+      'CustomDomain',
+      expect.objectContaining({
+        domainName: 'app.example.com',
+        subDomainSettings: [{ branchName: 'develop', prefix: 'dev' }],
       }),
     );
   });

--- a/infra/lib/versions/v2/amplify-hosting-stack.ts
+++ b/infra/lib/versions/v2/amplify-hosting-stack.ts
@@ -1,5 +1,5 @@
 import { CfnOutput, Fn } from 'aws-cdk-lib';
-import { CfnApp, CfnBranch } from 'aws-cdk-lib/aws-amplify';
+import { CfnApp, CfnBranch, CfnDomain } from 'aws-cdk-lib/aws-amplify';
 import { BaseStack, BaseStackProps } from '@core/base-stack';
 import { importFromVersion } from '@utils/cross-version';
 import type { Construct } from 'constructs';
@@ -41,6 +41,18 @@ export interface AmplifyHostingStackProps extends BaseStackProps {
   readonly assetsBucketUrl: string;
   /** Application URL. */
   readonly applicationUrl: string;
+  /**
+   * Root domain matching the Route53 Hosted Zone (e.g. financial-management.migudev.com).
+   * When set alongside customDomainPrefix, Amplify creates an ACM certificate and
+   * DNS records automatically. Requires a Route53 Hosted Zone in the same AWS account.
+   */
+  readonly customDomain?: string;
+  /**
+   * Subdomain prefix for the custom domain (e.g. 'dev' for dev.financial-management.migudev.com).
+   * Use empty string '' to map the root domain directly.
+   * @default ''
+   */
+  readonly customDomainPrefix?: string;
 }
 
 /**
@@ -145,6 +157,32 @@ export class AmplifyHostingStack extends BaseStack {
       stage: props.stage,
     });
     this.defaultBranch.addDependency(this.amplifyApp);
+
+    // ── Custom domain ────────────────────────────────────
+    if (props.customDomain) {
+      const prefix = props.customDomainPrefix ?? '';
+      const domain = new CfnDomain(this, 'CustomDomain', {
+        appId: this.amplifyApp.attrAppId,
+        domainName: props.customDomain,
+        subDomainSettings: [
+          {
+            branchName: defaultBranchName,
+            prefix,
+          },
+        ],
+        enableAutoSubDomain: false,
+      });
+      domain.addDependency(this.defaultBranch);
+
+      const fullDomain = prefix
+        ? `${prefix}.${props.customDomain}`
+        : props.customDomain;
+
+      new CfnOutput(this, 'CustomDomainUrl', {
+        value: `https://${fullDomain}`,
+        description: 'Custom domain URL for the Amplify app',
+      });
+    }
 
     new CfnOutput(this, 'AmplifyAppId', {
       value: this.amplifyApp.attrAppId,

--- a/infra/lib/versions/v2/index.ts
+++ b/infra/lib/versions/v2/index.ts
@@ -50,6 +50,8 @@ const createAmplifyHostingStack: NamedStackFactory = {
         appRoot: process.env.AMPLIFY_CLIENT_MAIN_ROOT ?? '',
         assetsBucketUrl: process.env.ASSETS_BUCKET_URL ?? '',
         applicationUrl: process.env.APPLICATION_URL ?? '',
+        customDomain: process.env.AMPLIFY_CUSTOM_DOMAIN || undefined,
+        customDomainPrefix: process.env.AMPLIFY_CUSTOM_DOMAIN_PREFIX ?? '',
       },
     ),
 };


### PR DESCRIPTION
## Description

### Core changes

- Adds optional custom domain support to the Amplify hosting stack by creating an `aws-amplify` `CfnDomain` resource when `AMPLIFY_CUSTOM_DOMAIN` is configured.
- Wires the new domain settings through the v2 infrastructure entrypoint, including support for subdomain mapping via `AMPLIFY_CUSTOM_DOMAIN_PREFIX`.
- Replaces the full-screen loading spinner in the dashboard expense list empty-loading state with skeleton cards, so the UI better matches the final layout while data is loading.
- Introduces a reusable `Skeleton` atom in the shared UI package and a dashboard-specific `ExpenseCardSkeleton` molecule for the expenses flow.

### Schema changes

- None. This PR does not introduce database schema changes, API contract changes, or payload shape changes.

### Minor changes

- Adds unit test coverage for the new Amplify custom domain behavior:
  - no domain resource is created when no custom domain is configured
  - the domain resource is created when a custom domain is provided
  - the configured branch is mapped correctly when a subdomain prefix is used
- Adds unit coverage for the new `Skeleton` and `ExpenseCardSkeleton` components.
- Updates expense list loading-state tests to reflect the skeleton-based behavior.
- Extends `config/.env.defaults` with the new Amplify domain configuration variables.

## Screenshots/Recordings

- No screenshots were attached as part of this change set.
- The infrastructure changes are non-visual.

## How to Test

1. Run the targeted automated checks that cover the scope of this PR:

   ```sh
   pnpm --filter @infra test -- amplify-hosting-stack.test.ts
   pnpm --filter @features/ui test -- skeleton
   pnpm --filter @features/dashboard test -- expense-list expense-card-skeleton
   ```

   Expected result: all test suites pass.

2. Validate the infrastructure configuration path:

   ```sh
   cp config/.env.defaults config/.env.local
   ```

   Update the following values in `config/.env.local`:

   ```sh
   AMPLIFY_CUSTOM_DOMAIN="financial-management.migudev.com"
   AMPLIFY_CUSTOM_DOMAIN_PREFIX="dev"
   ```

   Then synthesize the CDK app:

   ```sh
   cd infra && pnpm cdk synth
   ```

   Expected result: the Amplify hosting stack synthesizes successfully and includes a domain association for `dev.financial-management.migudev.com`.

3. Validate apex-domain behavior by setting the prefix to an empty string:

   ```sh
   AMPLIFY_CUSTOM_DOMAIN_PREFIX=""
   ```

   Re-run:

   ```sh
   cd infra && pnpm cdk synth
   ```

   Expected result: the stack still synthesizes successfully and the branch is mapped directly to the root domain.

4. Validate the dashboard loading experience manually:

   ```sh
   pnpm --filter @client/main web
   ```

   Navigate to the dashboard expenses view and reproduce the state where the list is loading and there are still no expenses in memory.

   Expected result:
   - the previous full-screen spinner is no longer shown in that scenario
   - five expense-card skeletons are rendered instead
   - once data resolves, the skeleton placeholders disappear and the real expense cards render normally
   - if loading finishes with no expenses, the existing empty state is still shown

## Checklist

- [x] The PR description includes clear instructions on how to test the implementation manually.

##### Added Tests?

- [x] yes
  - [x] Verified that this PR is not creating duplicate use cases
  - [x] All edge cases described in the acceptance criteria are covered, and tests have clear and descriptive names
- [ ] no, because they aren't needed
- [ ] no, because I need help

_Override these when needed._

<!-- START OVERRIDES -->

```sh
pnpm --filter @infra test -- amplify-hosting-stack.test.ts
pnpm --filter @features/ui test -- skeleton
pnpm --filter @features/dashboard test -- expense-list expense-card-skeleton
```

<!-- END OVERRIDES -->
