### PR TITLE
Logs config

### DIFF
--- a/infra/lib/versions/v1/cognito-stack.test.ts
+++ b/infra/lib/versions/v1/cognito-stack.test.ts
@@ -64,7 +64,7 @@ jest.mock('aws-cdk-lib/aws-logs', () => ({
     logGroupArn:
       'arn:aws:logs:us-east-1:123456789012:log-group:/aws/sns/sms/v1',
   })),
-  RetentionDays: { ONE_MONTH: 30 },
+  RetentionDays: { ONE_MONTH: 30, THREE_MONTHS: 90 },
 }));
 
 jest.mock('aws-cdk-lib/custom-resources', () => ({

--- a/infra/lib/versions/v1/cognito-stack.test.ts
+++ b/infra/lib/versions/v1/cognito-stack.test.ts
@@ -147,6 +147,7 @@ const defaultProps: CognitoStackProps = {
   removalProtect: false,
   emailsPrefix: 'dummy-emails-prefix',
   snsMonthlySpendLimit: '1',
+  stage: 'dev',
   smsBlockedCountries: ['US'],
   databaseUrl: 'postgresql://localhost:5432/test',
   databaseReadonlyUrl: 'postgresql://localhost:5432/test',

--- a/infra/lib/versions/v1/cognito-stack.ts
+++ b/infra/lib/versions/v1/cognito-stack.ts
@@ -81,6 +81,8 @@ export interface CognitoStackProps extends BaseStackProps {
   // Protection
   readonly removalProtect: boolean;
   readonly emailsPrefix: string;
+  // Stage (for friendly function names)
+  readonly stage: string;
   // Database (for user sync trigger)
   readonly databaseUrl: string;
   readonly databaseReadonlyUrl: string;
@@ -115,6 +117,7 @@ export class CognitoStack extends BaseStack {
       | undefined;
 
     const customMessageFn = new NodejsFunction(this, 'CustomMessageFn', {
+      functionName: `fm-${props.stage}-custom-message`,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -130,6 +133,7 @@ export class CognitoStack extends BaseStack {
       description: 'Cognito CustomMessage trigger for multi-language email/SMS',
       timeout: Duration.seconds(10),
       tracing: Tracing.ACTIVE,
+      logRetention: RetentionDays.THREE_MONTHS,
       environment: {
         ...(assetsStack?.bucket && {
           ASSETS_BUCKET_NAME: assetsStack.bucket.bucketName,
@@ -144,6 +148,7 @@ export class CognitoStack extends BaseStack {
 
     // ── User Sync Lambda Trigger ─────────────────────
     const userSyncFn = new NodejsFunction(this, 'UserSyncFn', {
+      functionName: `fm-${props.stage}-user-sync`,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -162,6 +167,7 @@ export class CognitoStack extends BaseStack {
         'Cognito PostConfirmation/PostAuthentication trigger — syncs users to DB',
       timeout: Duration.seconds(10),
       tracing: Tracing.ACTIVE,
+      logRetention: RetentionDays.THREE_MONTHS,
       environment: {
         DATABASE_URL: props.databaseUrl,
         DATABASE_READONLY_URL: props.databaseReadonlyUrl,
@@ -184,6 +190,7 @@ export class CognitoStack extends BaseStack {
 
     // ── Pre-Signup Lambda Trigger (social account linking) ──
     const preSignUpFn = new NodejsFunction(this, 'PreSignUpFn', {
+      functionName: `fm-${props.stage}-pre-signup`,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -200,6 +207,7 @@ export class CognitoStack extends BaseStack {
         'Cognito PreSignUp — links social providers to existing native accounts before signup',
       timeout: Duration.seconds(10),
       tracing: Tracing.ACTIVE,
+      logRetention: RetentionDays.THREE_MONTHS,
     });
 
     preSignUpFn.addToRolePolicy(

--- a/infra/lib/versions/v1/cognito-stack.ts
+++ b/infra/lib/versions/v1/cognito-stack.ts
@@ -116,8 +116,15 @@ export class CognitoStack extends BaseStack {
       | AssetsBucketStack
       | undefined;
 
+    const customMessageFnName = `fm-${props.stage}-custom-message`;
+    const customMessageLogGroup = new LogGroup(this, 'CustomMessageLogGroup', {
+      logGroupName: `/aws/lambda/${customMessageFnName}`,
+      retention: RetentionDays.THREE_MONTHS,
+      removalPolicy,
+    });
+
     const customMessageFn = new NodejsFunction(this, 'CustomMessageFn', {
-      functionName: `fm-${props.stage}-custom-message`,
+      functionName: customMessageFnName,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -133,7 +140,7 @@ export class CognitoStack extends BaseStack {
       description: 'Cognito CustomMessage trigger for multi-language email/SMS',
       timeout: Duration.seconds(10),
       tracing: Tracing.ACTIVE,
-      logRetention: RetentionDays.THREE_MONTHS,
+      logGroup: customMessageLogGroup,
       environment: {
         ...(assetsStack?.bucket && {
           ASSETS_BUCKET_NAME: assetsStack.bucket.bucketName,
@@ -147,8 +154,15 @@ export class CognitoStack extends BaseStack {
     }
 
     // ── User Sync Lambda Trigger ─────────────────────
+    const userSyncFnName = `fm-${props.stage}-user-sync`;
+    const userSyncLogGroup = new LogGroup(this, 'UserSyncLogGroup', {
+      logGroupName: `/aws/lambda/${userSyncFnName}`,
+      retention: RetentionDays.THREE_MONTHS,
+      removalPolicy,
+    });
+
     const userSyncFn = new NodejsFunction(this, 'UserSyncFn', {
-      functionName: `fm-${props.stage}-user-sync`,
+      functionName: userSyncFnName,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -167,7 +181,7 @@ export class CognitoStack extends BaseStack {
         'Cognito PostConfirmation/PostAuthentication trigger — syncs users to DB',
       timeout: Duration.seconds(10),
       tracing: Tracing.ACTIVE,
-      logRetention: RetentionDays.THREE_MONTHS,
+      logGroup: userSyncLogGroup,
       environment: {
         DATABASE_URL: props.databaseUrl,
         DATABASE_READONLY_URL: props.databaseReadonlyUrl,
@@ -189,8 +203,15 @@ export class CognitoStack extends BaseStack {
     );
 
     // ── Pre-Signup Lambda Trigger (social account linking) ──
+    const preSignUpFnName = `fm-${props.stage}-pre-signup`;
+    const preSignUpLogGroup = new LogGroup(this, 'PreSignUpLogGroup', {
+      logGroupName: `/aws/lambda/${preSignUpFnName}`,
+      retention: RetentionDays.THREE_MONTHS,
+      removalPolicy,
+    });
+
     const preSignUpFn = new NodejsFunction(this, 'PreSignUpFn', {
-      functionName: `fm-${props.stage}-pre-signup`,
+      functionName: preSignUpFnName,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -207,7 +228,7 @@ export class CognitoStack extends BaseStack {
         'Cognito PreSignUp — links social providers to existing native accounts before signup',
       timeout: Duration.seconds(10),
       tracing: Tracing.ACTIVE,
-      logRetention: RetentionDays.THREE_MONTHS,
+      logGroup: preSignUpLogGroup,
     });
 
     preSignUpFn.addToRolePolicy(

--- a/infra/lib/versions/v1/cognito-stack.ts
+++ b/infra/lib/versions/v1/cognito-stack.ts
@@ -136,6 +136,7 @@ export class CognitoStack extends BaseStack {
         sourceMap: true,
         minify: true,
         nodeModules: ['aws-xray-sdk-core'],
+        environment: { npm_config_trust_policy: 'lenient' },
       },
       description: 'Cognito CustomMessage trigger for multi-language email/SMS',
       timeout: Duration.seconds(10),
@@ -176,6 +177,7 @@ export class CognitoStack extends BaseStack {
         banner:
           "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
         nodeModules: ['aws-xray-sdk-core'],
+        environment: { npm_config_trust_policy: 'lenient' },
       },
       description:
         'Cognito PostConfirmation/PostAuthentication trigger — syncs users to DB',
@@ -223,6 +225,7 @@ export class CognitoStack extends BaseStack {
         sourceMap: true,
         minify: true,
         nodeModules: ['aws-xray-sdk-core'],
+        environment: { npm_config_trust_policy: 'lenient' },
       },
       description:
         'Cognito PreSignUp — links social providers to existing native accounts before signup',

--- a/infra/lib/versions/v1/index.ts
+++ b/infra/lib/versions/v1/index.ts
@@ -64,6 +64,7 @@ const createAuthStack: NamedStackFactory = {
         emailsPrefix: process.env.EMAILS_PREFIX ?? '',
         databaseUrl: process.env.DATABASE_URL ?? '',
         databaseReadonlyUrl: process.env.DATABASE_READONLY_URL ?? '',
+        stage: process.env.STAGE ?? 'dev',
       },
     ),
 };

--- a/infra/lib/versions/v2/index.ts
+++ b/infra/lib/versions/v2/index.ts
@@ -76,6 +76,7 @@ const createLambdaExpensesStack: NamedStackFactory = {
         allowedOrigins: (process.env.ALLOWED_ORIGINS ?? '')
           .split(',')
           .map((origin) => origin.trim()),
+        stage: process.env.STAGE ?? 'dev',
       },
     ),
 };
@@ -96,6 +97,7 @@ const createLambdaDocumentsStack: NamedStackFactory = {
         allowedOrigins: (process.env.ALLOWED_ORIGINS ?? '')
           .split(',')
           .map((origin) => origin.trim()),
+        stage: process.env.STAGE ?? 'dev',
       },
     ),
 };
@@ -116,6 +118,7 @@ const createLambdaCurrenciesStack: NamedStackFactory = {
         allowedOrigins: (process.env.ALLOWED_ORIGINS ?? '')
           .split(',')
           .map((origin) => origin.trim()),
+        stage: process.env.STAGE ?? 'dev',
       },
     ),
 };
@@ -136,6 +139,7 @@ const createLambdaUsersStack: NamedStackFactory = {
         allowedOrigins: (process.env.ALLOWED_ORIGINS ?? '')
           .split(',')
           .map((origin) => origin.trim()),
+        stage: process.env.STAGE ?? 'dev',
       },
     ),
 };

--- a/infra/lib/versions/v2/lambda-currencies-stack.test.ts
+++ b/infra/lib/versions/v2/lambda-currencies-stack.test.ts
@@ -73,6 +73,7 @@ const defaultProps = {
   databaseUrl: 'postgresql://localhost:5432/test',
   databaseReadonlyUrl: 'postgresql://localhost:5432/test',
   allowedOrigins: ['https://dev-financial-management.migudev.com'],
+  stage: 'dev',
   deps: mockDeps,
 };
 

--- a/infra/lib/versions/v2/lambda-currencies-stack.test.ts
+++ b/infra/lib/versions/v2/lambda-currencies-stack.test.ts
@@ -60,6 +60,11 @@ jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => ({
   OutputFormat: { ESM: 'ESM' },
 }));
 
+jest.mock('aws-cdk-lib/aws-logs', () => ({
+  LogGroup: jest.fn(),
+  RetentionDays: { THREE_MONTHS: 90 },
+}));
+
 jest.mock('aws-cdk-lib/aws-apigateway', () => ({
   LambdaIntegration: jest.fn().mockImplementation(() => ({
     integrationId: 'mock-integration',

--- a/infra/lib/versions/v2/lambda-currencies-stack.ts
+++ b/infra/lib/versions/v2/lambda-currencies-stack.ts
@@ -4,6 +4,7 @@ import type { StackDeps } from '@utils/types';
 import { Duration } from 'aws-cdk-lib';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { join } from 'path';
 import { ApiGatewayStack } from './api-gateway-stack';
@@ -14,6 +15,7 @@ export interface LambdaCurrenciesStackProps extends BaseStackProps {
   readonly databaseUrl: string;
   readonly databaseReadonlyUrl: string;
   readonly allowedOrigins: string[];
+  readonly stage: string;
 }
 
 export class LambdaCurrenciesStack extends BaseStack {
@@ -28,6 +30,7 @@ export class LambdaCurrenciesStack extends BaseStack {
       databaseReadonlyUrl,
       allowedOrigins,
       deps,
+      stage,
     } = props;
     super(scope, id, { version, stackName, description });
 
@@ -35,6 +38,7 @@ export class LambdaCurrenciesStack extends BaseStack {
 
     // ── Lambda Function ─────────────────────────────────────
     const lambda = new NodejsFunction(this, `${stackName}-CurrenciesFn`, {
+      functionName: `fm-${stage}-currencies`,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -51,6 +55,7 @@ export class LambdaCurrenciesStack extends BaseStack {
       handler: 'handler',
       timeout: Duration.seconds(30),
       tracing: Tracing.ACTIVE,
+      logRetention: RetentionDays.THREE_MONTHS,
       environment: {
         DATABASE_URL: databaseUrl,
         DATABASE_READONLY_URL: databaseReadonlyUrl,

--- a/infra/lib/versions/v2/lambda-currencies-stack.ts
+++ b/infra/lib/versions/v2/lambda-currencies-stack.ts
@@ -55,6 +55,7 @@ export class LambdaCurrenciesStack extends BaseStack {
         sourceMap: true,
         minify: true,
         nodeModules: ['aws-xray-sdk-core'],
+        environment: { npm_config_trust_policy: 'lenient' },
         banner:
           "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
       },

--- a/infra/lib/versions/v2/lambda-currencies-stack.ts
+++ b/infra/lib/versions/v2/lambda-currencies-stack.ts
@@ -4,7 +4,7 @@ import type { StackDeps } from '@utils/types';
 import { Duration } from 'aws-cdk-lib';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { join } from 'path';
 import { ApiGatewayStack } from './api-gateway-stack';
@@ -37,8 +37,14 @@ export class LambdaCurrenciesStack extends BaseStack {
     const gateway = deps?.getStack(ActiveStack.API_GATEWAY) as ApiGatewayStack;
 
     // ── Lambda Function ─────────────────────────────────────
+    const fnName = `fm-${stage}-currencies`;
+    const logGroup = new LogGroup(this, `${stackName}-CurrenciesLogGroup`, {
+      logGroupName: `/aws/lambda/${fnName}`,
+      retention: RetentionDays.THREE_MONTHS,
+    });
+
     const lambda = new NodejsFunction(this, `${stackName}-CurrenciesFn`, {
-      functionName: `fm-${stage}-currencies`,
+      functionName: fnName,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -55,7 +61,7 @@ export class LambdaCurrenciesStack extends BaseStack {
       handler: 'handler',
       timeout: Duration.seconds(30),
       tracing: Tracing.ACTIVE,
-      logRetention: RetentionDays.THREE_MONTHS,
+      logGroup,
       environment: {
         DATABASE_URL: databaseUrl,
         DATABASE_READONLY_URL: databaseReadonlyUrl,

--- a/infra/lib/versions/v2/lambda-documents-stack.test.ts
+++ b/infra/lib/versions/v2/lambda-documents-stack.test.ts
@@ -73,6 +73,7 @@ const defaultProps = {
   databaseUrl: 'postgresql://localhost:5432/test',
   databaseReadonlyUrl: 'postgresql://localhost:5432/test',
   allowedOrigins: ['https://dev-financial-management.migudev.com'],
+  stage: 'dev',
   deps: mockDeps,
 };
 

--- a/infra/lib/versions/v2/lambda-documents-stack.test.ts
+++ b/infra/lib/versions/v2/lambda-documents-stack.test.ts
@@ -60,6 +60,11 @@ jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => ({
   OutputFormat: { ESM: 'ESM' },
 }));
 
+jest.mock('aws-cdk-lib/aws-logs', () => ({
+  LogGroup: jest.fn(),
+  RetentionDays: { THREE_MONTHS: 90 },
+}));
+
 jest.mock('aws-cdk-lib/aws-apigateway', () => ({
   LambdaIntegration: jest.fn().mockImplementation(() => ({
     integrationId: 'mock-integration',

--- a/infra/lib/versions/v2/lambda-documents-stack.ts
+++ b/infra/lib/versions/v2/lambda-documents-stack.ts
@@ -55,6 +55,7 @@ export class LambdaDocumentsStack extends BaseStack {
         sourceMap: true,
         minify: true,
         nodeModules: ['aws-xray-sdk-core'],
+        environment: { npm_config_trust_policy: 'lenient' },
         banner:
           "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
       },

--- a/infra/lib/versions/v2/lambda-documents-stack.ts
+++ b/infra/lib/versions/v2/lambda-documents-stack.ts
@@ -4,7 +4,7 @@ import type { StackDeps } from '@utils/types';
 import { Duration } from 'aws-cdk-lib';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { join } from 'path';
 import { ApiGatewayStack } from './api-gateway-stack';
@@ -37,8 +37,14 @@ export class LambdaDocumentsStack extends BaseStack {
     const gateway = deps?.getStack(ActiveStack.API_GATEWAY) as ApiGatewayStack;
 
     // ── Lambda Function ─────────────────────────────────────
+    const fnName = `fm-${stage}-documents`;
+    const logGroup = new LogGroup(this, `${stackName}-DocumentsLogGroup`, {
+      logGroupName: `/aws/lambda/${fnName}`,
+      retention: RetentionDays.THREE_MONTHS,
+    });
+
     const lambda = new NodejsFunction(this, `${stackName}-DocumentsFn`, {
-      functionName: `fm-${stage}-documents`,
+      functionName: fnName,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -55,7 +61,7 @@ export class LambdaDocumentsStack extends BaseStack {
       handler: 'handler',
       timeout: Duration.seconds(30),
       tracing: Tracing.ACTIVE,
-      logRetention: RetentionDays.THREE_MONTHS,
+      logGroup,
       environment: {
         DATABASE_URL: databaseUrl,
         DATABASE_READONLY_URL: databaseReadonlyUrl,

--- a/infra/lib/versions/v2/lambda-documents-stack.ts
+++ b/infra/lib/versions/v2/lambda-documents-stack.ts
@@ -4,6 +4,7 @@ import type { StackDeps } from '@utils/types';
 import { Duration } from 'aws-cdk-lib';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { join } from 'path';
 import { ApiGatewayStack } from './api-gateway-stack';
@@ -14,6 +15,7 @@ export interface LambdaDocumentsStackProps extends BaseStackProps {
   readonly databaseUrl: string;
   readonly databaseReadonlyUrl: string;
   readonly allowedOrigins: string[];
+  readonly stage: string;
 }
 
 export class LambdaDocumentsStack extends BaseStack {
@@ -28,6 +30,7 @@ export class LambdaDocumentsStack extends BaseStack {
       databaseReadonlyUrl,
       allowedOrigins,
       deps,
+      stage,
     } = props;
     super(scope, id, { version, stackName, description });
 
@@ -35,6 +38,7 @@ export class LambdaDocumentsStack extends BaseStack {
 
     // ── Lambda Function ─────────────────────────────────────
     const lambda = new NodejsFunction(this, `${stackName}-DocumentsFn`, {
+      functionName: `fm-${stage}-documents`,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -51,6 +55,7 @@ export class LambdaDocumentsStack extends BaseStack {
       handler: 'handler',
       timeout: Duration.seconds(30),
       tracing: Tracing.ACTIVE,
+      logRetention: RetentionDays.THREE_MONTHS,
       environment: {
         DATABASE_URL: databaseUrl,
         DATABASE_READONLY_URL: databaseReadonlyUrl,

--- a/infra/lib/versions/v2/lambda-expenses-stack.test.ts
+++ b/infra/lib/versions/v2/lambda-expenses-stack.test.ts
@@ -79,6 +79,11 @@ jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => ({
   OutputFormat: { ESM: 'ESM' },
 }));
 
+jest.mock('aws-cdk-lib/aws-logs', () => ({
+  LogGroup: jest.fn(),
+  RetentionDays: { THREE_MONTHS: 90 },
+}));
+
 jest.mock('aws-cdk-lib/aws-apigateway', () => ({
   LambdaIntegration: jest.fn().mockImplementation(() => ({
     integrationId: 'mock-integration',

--- a/infra/lib/versions/v2/lambda-expenses-stack.test.ts
+++ b/infra/lib/versions/v2/lambda-expenses-stack.test.ts
@@ -98,6 +98,7 @@ const defaultProps = {
   databaseUrl: 'postgresql://localhost:5432/test',
   databaseReadonlyUrl: 'postgresql://localhost:5432/test',
   allowedOrigins: ['https://dev-financial-management.migudev.com'],
+  stage: 'dev',
   deps: mockDeps,
 };
 

--- a/infra/lib/versions/v2/lambda-expenses-stack.ts
+++ b/infra/lib/versions/v2/lambda-expenses-stack.ts
@@ -5,6 +5,7 @@ import { Duration } from 'aws-cdk-lib';
 import type { JsonSchema } from 'aws-cdk-lib/aws-apigateway';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
   createExpenseSchema,
   patchExpenseSchema,
@@ -20,6 +21,7 @@ export interface LambdaExpensesStackProps extends BaseStackProps {
   readonly databaseUrl: string;
   readonly databaseReadonlyUrl: string;
   readonly allowedOrigins: string[];
+  readonly stage: string;
 }
 
 export class LambdaExpensesStack extends BaseStack {
@@ -41,6 +43,7 @@ export class LambdaExpensesStack extends BaseStack {
       databaseReadonlyUrl,
       allowedOrigins,
       deps,
+      stage,
     } = props;
     super(scope, id, { version, stackName, description });
 
@@ -48,6 +51,7 @@ export class LambdaExpensesStack extends BaseStack {
 
     // ── Lambda Function ─────────────────────────────────────
     const lambda = new NodejsFunction(this, `${stackName}-ExpensesFn`, {
+      functionName: `fm-${stage}-expenses`,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -64,6 +68,7 @@ export class LambdaExpensesStack extends BaseStack {
       handler: 'handler',
       timeout: Duration.seconds(30),
       tracing: Tracing.ACTIVE,
+      logRetention: RetentionDays.THREE_MONTHS,
       environment: {
         DATABASE_URL: databaseUrl,
         DATABASE_READONLY_URL: databaseReadonlyUrl,

--- a/infra/lib/versions/v2/lambda-expenses-stack.ts
+++ b/infra/lib/versions/v2/lambda-expenses-stack.ts
@@ -68,6 +68,7 @@ export class LambdaExpensesStack extends BaseStack {
         sourceMap: true,
         minify: true,
         nodeModules: ['aws-xray-sdk-core'],
+        environment: { npm_config_trust_policy: 'lenient' },
         banner:
           "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
       },

--- a/infra/lib/versions/v2/lambda-expenses-stack.ts
+++ b/infra/lib/versions/v2/lambda-expenses-stack.ts
@@ -5,7 +5,7 @@ import { Duration } from 'aws-cdk-lib';
 import type { JsonSchema } from 'aws-cdk-lib/aws-apigateway';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
   createExpenseSchema,
   patchExpenseSchema,
@@ -50,8 +50,14 @@ export class LambdaExpensesStack extends BaseStack {
     const gateway = deps?.getStack(ActiveStack.API_GATEWAY) as ApiGatewayStack;
 
     // ── Lambda Function ─────────────────────────────────────
+    const fnName = `fm-${stage}-expenses`;
+    const logGroup = new LogGroup(this, `${stackName}-ExpensesLogGroup`, {
+      logGroupName: `/aws/lambda/${fnName}`,
+      retention: RetentionDays.THREE_MONTHS,
+    });
+
     const lambda = new NodejsFunction(this, `${stackName}-ExpensesFn`, {
-      functionName: `fm-${stage}-expenses`,
+      functionName: fnName,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -68,7 +74,7 @@ export class LambdaExpensesStack extends BaseStack {
       handler: 'handler',
       timeout: Duration.seconds(30),
       tracing: Tracing.ACTIVE,
-      logRetention: RetentionDays.THREE_MONTHS,
+      logGroup,
       environment: {
         DATABASE_URL: databaseUrl,
         DATABASE_READONLY_URL: databaseReadonlyUrl,

--- a/infra/lib/versions/v2/lambda-users-stack.test.ts
+++ b/infra/lib/versions/v2/lambda-users-stack.test.ts
@@ -94,6 +94,7 @@ const defaultProps = {
   databaseUrl: 'postgresql://localhost:5432/test',
   databaseReadonlyUrl: 'postgresql://localhost:5432/test',
   allowedOrigins: ['https://dev-financial-management.migudev.com'],
+  stage: 'dev',
   deps: mockDeps,
 };
 

--- a/infra/lib/versions/v2/lambda-users-stack.test.ts
+++ b/infra/lib/versions/v2/lambda-users-stack.test.ts
@@ -75,6 +75,11 @@ jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => ({
   OutputFormat: { ESM: 'ESM' },
 }));
 
+jest.mock('aws-cdk-lib/aws-logs', () => ({
+  LogGroup: jest.fn(),
+  RetentionDays: { THREE_MONTHS: 90 },
+}));
+
 jest.mock('aws-cdk-lib/aws-apigateway', () => ({
   LambdaIntegration: jest.fn().mockImplementation(() => ({
     integrationId: 'mock-integration',

--- a/infra/lib/versions/v2/lambda-users-stack.ts
+++ b/infra/lib/versions/v2/lambda-users-stack.ts
@@ -65,6 +65,7 @@ export class LambdaUsersStack extends BaseStack {
         sourceMap: true,
         minify: true,
         nodeModules: ['aws-xray-sdk-core'],
+        environment: { npm_config_trust_policy: 'lenient' },
         banner:
           "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
       },

--- a/infra/lib/versions/v2/lambda-users-stack.ts
+++ b/infra/lib/versions/v2/lambda-users-stack.ts
@@ -5,6 +5,7 @@ import { Duration } from 'aws-cdk-lib';
 import type { JsonSchema } from 'aws-cdk-lib/aws-apigateway';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
   createUserSchema,
   patchUserSchema,
@@ -19,6 +20,7 @@ export interface LambdaUsersStackProps extends BaseStackProps {
   readonly databaseUrl: string;
   readonly databaseReadonlyUrl: string;
   readonly allowedOrigins: string[];
+  readonly stage: string;
 }
 
 export class LambdaUsersStack extends BaseStack {
@@ -38,6 +40,7 @@ export class LambdaUsersStack extends BaseStack {
       databaseReadonlyUrl,
       allowedOrigins,
       deps,
+      stage,
     } = props;
     super(scope, id, { version, stackName, description });
 
@@ -45,6 +48,7 @@ export class LambdaUsersStack extends BaseStack {
 
     // ── Lambda Function ─────────────────────────────────────
     const lambda = new NodejsFunction(this, `${stackName}-UsersFn`, {
+      functionName: `fm-${stage}-users`,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -61,6 +65,7 @@ export class LambdaUsersStack extends BaseStack {
       handler: 'handler',
       timeout: Duration.seconds(30),
       tracing: Tracing.ACTIVE,
+      logRetention: RetentionDays.THREE_MONTHS,
       environment: {
         DATABASE_URL: databaseUrl,
         DATABASE_READONLY_URL: databaseReadonlyUrl,

--- a/infra/lib/versions/v2/lambda-users-stack.ts
+++ b/infra/lib/versions/v2/lambda-users-stack.ts
@@ -5,7 +5,7 @@ import { Duration } from 'aws-cdk-lib';
 import type { JsonSchema } from 'aws-cdk-lib/aws-apigateway';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
   createUserSchema,
   patchUserSchema,
@@ -47,8 +47,14 @@ export class LambdaUsersStack extends BaseStack {
     const gateway = deps?.getStack(ActiveStack.API_GATEWAY) as ApiGatewayStack;
 
     // ── Lambda Function ─────────────────────────────────────
+    const fnName = `fm-${stage}-users`;
+    const logGroup = new LogGroup(this, `${stackName}-UsersLogGroup`, {
+      logGroupName: `/aws/lambda/${fnName}`,
+      retention: RetentionDays.THREE_MONTHS,
+    });
+
     const lambda = new NodejsFunction(this, `${stackName}-UsersFn`, {
-      functionName: `fm-${stage}-users`,
+      functionName: fnName,
       runtime: Runtime.NODEJS_22_X,
       entry: join(
         __dirname,
@@ -65,7 +71,7 @@ export class LambdaUsersStack extends BaseStack {
       handler: 'handler',
       timeout: Duration.seconds(30),
       tracing: Tracing.ACTIVE,
-      logRetention: RetentionDays.THREE_MONTHS,
+      logGroup,
       environment: {
         DATABASE_URL: databaseUrl,
         DATABASE_READONLY_URL: databaseReadonlyUrl,

--- a/infra/lib/versions/v3/index.ts
+++ b/infra/lib/versions/v3/index.ts
@@ -18,6 +18,7 @@ const createMonitoringStack: NamedStackFactory = {
           'CloudWatch dashboard, alarms, and SNS notifications for all services',
         alertEmail: process.env.ALERT_EMAIL_TO ?? '',
         alertFromEmail: process.env.ALERT_EMAIL_FROM ?? '',
+        stage: process.env.STAGE ?? 'dev',
         dependsOn: [
           V2Stack.API_GATEWAY,
           V2Stack.LAMBDA_EXPENSES,

--- a/infra/lib/versions/v3/monitoring-stack.test.ts
+++ b/infra/lib/versions/v3/monitoring-stack.test.ts
@@ -31,6 +31,7 @@ jest.mock('aws-cdk-lib/aws-cloudwatch', () => ({
   ComparisonOperator: { GREATER_THAN_THRESHOLD: 'GREATER_THAN_THRESHOLD' },
   Dashboard: jest.fn().mockImplementation(() => mockDashboard),
   GraphWidget: jest.fn(),
+  LogQueryWidget: jest.fn(),
   Metric: jest.fn().mockImplementation(() => ({
     with: jest.fn().mockReturnThis(),
   })),
@@ -63,8 +64,26 @@ jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => ({
   OutputFormat: { ESM: 'esm' },
 }));
 
+jest.mock('aws-cdk-lib/aws-logs', () => ({
+  RetentionDays: { THREE_MONTHS: 90 },
+}));
+
 jest.mock('aws-cdk-lib/aws-iam', () => ({
   PolicyStatement: jest.fn(),
+}));
+
+jest.mock('aws-cdk-lib/aws-ses', () => ({
+  CfnConfigurationSet: jest.fn(),
+  CfnConfigurationSetEventDestination: jest.fn(),
+}));
+
+jest.mock('aws-cdk-lib/aws-events', () => ({
+  Rule: jest.fn(),
+  EventPattern: jest.fn(),
+}));
+
+jest.mock('aws-cdk-lib/aws-events-targets', () => ({
+  SnsTopic: jest.fn(),
 }));
 
 jest.mock('@utils/cross-version', () => ({
@@ -83,6 +102,7 @@ const defaultProps = {
   alertEmail: 'alerts@example.com',
   alertFromEmail: 'noreply@example.com',
   dashboardUrl: 'https://console.aws.amazon.com/cloudwatch',
+  stage: 'dev',
 };
 
 describe('MonitoringStack', () => {

--- a/infra/lib/versions/v3/monitoring-stack.test.ts
+++ b/infra/lib/versions/v3/monitoring-stack.test.ts
@@ -5,6 +5,7 @@ const mockAlarm = { addAlarmAction: jest.fn() };
 const mockDashboard = { addWidgets: jest.fn() };
 const mockTopic = {
   addSubscription: jest.fn(),
+  addToResourcePolicy: jest.fn(),
   topicArn: 'arn:aws:sns:us-east-1:123:topic',
 };
 
@@ -71,6 +72,7 @@ jest.mock('aws-cdk-lib/aws-logs', () => ({
 
 jest.mock('aws-cdk-lib/aws-iam', () => ({
   PolicyStatement: jest.fn(),
+  ServicePrincipal: jest.fn(),
 }));
 
 jest.mock('aws-cdk-lib/aws-ses', () => ({

--- a/infra/lib/versions/v3/monitoring-stack.test.ts
+++ b/infra/lib/versions/v3/monitoring-stack.test.ts
@@ -65,6 +65,7 @@ jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => ({
 }));
 
 jest.mock('aws-cdk-lib/aws-logs', () => ({
+  LogGroup: jest.fn(),
   RetentionDays: { THREE_MONTHS: 90 },
 }));
 

--- a/infra/lib/versions/v3/monitoring-stack.ts
+++ b/infra/lib/versions/v3/monitoring-stack.ts
@@ -516,7 +516,7 @@ export class MonitoringStack extends BaseStack {
         detailType: ['Amplify Deployment Status Change'],
         detail: {
           appId: [amplifyAppId],
-          jobStatus: ['FAILED'],
+          jobStatus: ['FAILED', 'SUCCEED'],
         },
       } as EventPattern,
       targets: [new SnsTopic(this.alertTopic)],

--- a/infra/lib/versions/v3/monitoring-stack.ts
+++ b/infra/lib/versions/v3/monitoring-stack.ts
@@ -420,6 +420,34 @@ export class MonitoringStack extends BaseStack {
       }),
     );
 
+    // ── Cognito Logs Insights section ──────────────────────
+    this.dashboard.addWidgets(
+      new TextWidget({
+        markdown: '## Cognito Trigger Errors (Logs Insights)',
+        width: 24,
+        height: 1,
+      }),
+    );
+
+    const triggerLogGroups = Object.entries(cognitoTriggers).map(
+      ([, fnName]) => `/aws/lambda/${fnName}`,
+    );
+
+    this.dashboard.addWidgets(
+      new LogQueryWidget({
+        title: 'Recent Cognito Trigger Errors',
+        logGroupNames: triggerLogGroups,
+        queryLines: [
+          'fields @timestamp, @message',
+          'filter level = "ERROR" or @message like /ERROR/',
+          'sort @timestamp desc',
+          'limit 20',
+        ],
+        width: 24,
+        height: 6,
+      }),
+    );
+
     // Amplify section
     this.dashboard.addWidgets(
       new TextWidget({
@@ -456,34 +484,6 @@ export class MonitoringStack extends BaseStack {
           amplifyMetric('Latency', 'p90'),
         ],
         width: 8,
-      }),
-    );
-
-    // ── Cognito Logs Insights section ──────────────────────
-    this.dashboard.addWidgets(
-      new TextWidget({
-        markdown: '## Cognito Trigger Errors (Logs Insights)',
-        width: 24,
-        height: 1,
-      }),
-    );
-
-    const triggerLogGroups = Object.entries(cognitoTriggers).map(
-      ([, fnName]) => `/aws/lambda/${fnName}`,
-    );
-
-    this.dashboard.addWidgets(
-      new LogQueryWidget({
-        title: 'Recent Cognito Trigger Errors',
-        logGroupNames: triggerLogGroups,
-        queryLines: [
-          'fields @timestamp, @message',
-          'filter level = "ERROR" or @message like /ERROR/',
-          'sort @timestamp desc',
-          'limit 20',
-        ],
-        width: 24,
-        height: 6,
       }),
     );
 
@@ -539,7 +539,7 @@ export class MonitoringStack extends BaseStack {
         detailType: ['Amplify Deployment Status Change'],
         detail: {
           appId: [amplifyAppId],
-          jobStatus: ['FAILED', 'SUCCEED'],
+          jobStatus: ['STARTED', 'FAILED', 'SUCCEED'],
         },
       } as EventPattern,
       targets: [new SnsTopic(this.alertTopic)],

--- a/infra/lib/versions/v3/monitoring-stack.ts
+++ b/infra/lib/versions/v3/monitoring-stack.ts
@@ -15,7 +15,7 @@ import { Rule, EventPattern } from 'aws-cdk-lib/aws-events';
 import { SnsTopic } from 'aws-cdk-lib/aws-events-targets';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import {
   CfnConfigurationSet,
@@ -59,11 +59,21 @@ export class MonitoringStack extends BaseStack {
       'AssetsBucketName',
     );
 
+    const notificationFnName = `fm-${props.stage}-notifications`;
+    const notificationLogGroup = new LogGroup(
+      this,
+      `${stackName}-NotificationLogGroup`,
+      {
+        logGroupName: `/aws/lambda/${notificationFnName}`,
+        retention: RetentionDays.THREE_MONTHS,
+      },
+    );
+
     const notificationFn = new NodejsFunction(
       this,
       `${stackName}-NotificationFn`,
       {
-        functionName: `fm-${props.stage}-notifications`,
+        functionName: notificationFnName,
         runtime: Runtime.NODEJS_22_X,
         entry: join(
           __dirname,
@@ -79,7 +89,7 @@ export class MonitoringStack extends BaseStack {
         description:
           'Sends formatted alert emails via SES on CloudWatch alarms',
         tracing: Tracing.ACTIVE,
-        logRetention: RetentionDays.THREE_MONTHS,
+        logGroup: notificationLogGroup,
         environment: {
           ALERT_EMAIL_FROM: props.alertFromEmail,
           ALERT_EMAIL_TO: props.alertEmail,

--- a/infra/lib/versions/v3/monitoring-stack.ts
+++ b/infra/lib/versions/v3/monitoring-stack.ts
@@ -16,7 +16,7 @@ import { SnsTopic } from 'aws-cdk-lib/aws-events-targets';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import {
   CfnConfigurationSet,
   CfnConfigurationSetEventDestination,
@@ -85,6 +85,7 @@ export class MonitoringStack extends BaseStack {
           sourceMap: true,
           minify: true,
           nodeModules: ['aws-xray-sdk-core'],
+          environment: { npm_config_trust_policy: 'lenient' },
         },
         description:
           'Sends formatted alert emails via SES on CloudWatch alarms',
@@ -483,6 +484,18 @@ export class MonitoringStack extends BaseStack {
         ],
         width: 24,
         height: 6,
+      }),
+    );
+
+    // ── SNS Topic Policy (allow SES + EventBridge to publish) ──
+    this.alertTopic.addToResourcePolicy(
+      new PolicyStatement({
+        actions: ['sns:Publish'],
+        principals: [
+          new ServicePrincipal('ses.amazonaws.com'),
+          new ServicePrincipal('events.amazonaws.com'),
+        ],
+        resources: [this.alertTopic.topicArn],
       }),
     );
 

--- a/infra/lib/versions/v3/monitoring-stack.ts
+++ b/infra/lib/versions/v3/monitoring-stack.ts
@@ -97,6 +97,7 @@ export class MonitoringStack extends BaseStack {
           DASHBOARD_URL: `https://console.aws.amazon.com/cloudwatch/home#dashboards:name=${stackName}-Dashboard`,
           ASSETS_BUCKET_NAME: assetsBucketName,
           EMAILS_PREFIX: process.env.EMAILS_PREFIX ?? 'emails',
+          SES_CONFIGURATION_SET_NAME: `${stackName}-ses-events`,
         },
         timeout: Duration.seconds(10),
       },
@@ -491,11 +492,21 @@ export class MonitoringStack extends BaseStack {
     this.alertTopic.addToResourcePolicy(
       new PolicyStatement({
         actions: ['sns:Publish'],
-        principals: [
-          new ServicePrincipal('ses.amazonaws.com'),
-          new ServicePrincipal('events.amazonaws.com'),
-        ],
+        principals: [new ServicePrincipal('ses.amazonaws.com')],
         resources: [this.alertTopic.topicArn],
+        conditions: {
+          StringEquals: { 'AWS:SourceAccount': this.account },
+        },
+      }),
+    );
+    this.alertTopic.addToResourcePolicy(
+      new PolicyStatement({
+        actions: ['sns:Publish'],
+        principals: [new ServicePrincipal('events.amazonaws.com')],
+        resources: [this.alertTopic.topicArn],
+        conditions: {
+          StringEquals: { 'AWS:SourceAccount': this.account },
+        },
       }),
     );
 
@@ -531,9 +542,10 @@ export class MonitoringStack extends BaseStack {
     );
 
     // ── EventBridge Rule: Amplify Build Failures ──────────
-    new Rule(this, `${stackName}-AmplifyBuildFailRule`, {
-      ruleName: `${stackName}-Amplify-Build-Fail`,
-      description: 'Captures Amplify build failures and sends alerts',
+    new Rule(this, `${stackName}-AmplifyBuildRule`, {
+      ruleName: `${stackName}-Amplify-Build-Status`,
+      description:
+        'Captures Amplify build status changes (started, failed, succeed) and sends alerts',
       eventPattern: {
         source: ['aws.amplify'],
         detailType: ['Amplify Deployment Status Change'],

--- a/infra/lib/versions/v3/monitoring-stack.ts
+++ b/infra/lib/versions/v3/monitoring-stack.ts
@@ -4,15 +4,23 @@ import {
   ComparisonOperator,
   Dashboard,
   GraphWidget,
+  LogQueryWidget,
   Metric,
   TextWidget,
   TreatMissingData,
   AlarmStatusWidget,
 } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
+import { Rule, EventPattern } from 'aws-cdk-lib/aws-events';
+import { SnsTopic } from 'aws-cdk-lib/aws-events-targets';
 import { Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import {
+  CfnConfigurationSet,
+  CfnConfigurationSetEventDestination,
+} from 'aws-cdk-lib/aws-ses';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { BaseStack, BaseStackProps } from '@core/base-stack';
@@ -25,6 +33,8 @@ export interface MonitoringStackProps extends BaseStackProps {
   readonly alertEmail: string;
   /** Email address used as sender (must be verified in SES). */
   readonly alertFromEmail: string;
+  /** Stage name for friendly function naming (e.g. 'dev', 'prod'). */
+  readonly stage: string;
 }
 
 export class MonitoringStack extends BaseStack {
@@ -53,6 +63,7 @@ export class MonitoringStack extends BaseStack {
       this,
       `${stackName}-NotificationFn`,
       {
+        functionName: `fm-${props.stage}-notifications`,
         runtime: Runtime.NODEJS_22_X,
         entry: join(
           __dirname,
@@ -68,6 +79,7 @@ export class MonitoringStack extends BaseStack {
         description:
           'Sends formatted alert emails via SES on CloudWatch alarms',
         tracing: Tracing.ACTIVE,
+        logRetention: RetentionDays.THREE_MONTHS,
         environment: {
           ALERT_EMAIL_FROM: props.alertFromEmail,
           ALERT_EMAIL_TO: props.alertEmail,
@@ -435,6 +447,80 @@ export class MonitoringStack extends BaseStack {
         width: 8,
       }),
     );
+
+    // ── Cognito Logs Insights section ──────────────────────
+    this.dashboard.addWidgets(
+      new TextWidget({
+        markdown: '## Cognito Trigger Errors (Logs Insights)',
+        width: 24,
+        height: 1,
+      }),
+    );
+
+    const triggerLogGroups = Object.entries(cognitoTriggers).map(
+      ([, fnName]) => `/aws/lambda/${fnName}`,
+    );
+
+    this.dashboard.addWidgets(
+      new LogQueryWidget({
+        title: 'Recent Cognito Trigger Errors',
+        logGroupNames: triggerLogGroups,
+        queryLines: [
+          'fields @timestamp, @message',
+          'filter level = "ERROR" or @message like /ERROR/',
+          'sort @timestamp desc',
+          'limit 20',
+        ],
+        width: 24,
+        height: 6,
+      }),
+    );
+
+    // ── SES Configuration Set (bounce/complaint tracking) ──
+    const sesConfigSet = new CfnConfigurationSet(
+      this,
+      `${stackName}-SesConfigSet`,
+      {
+        name: `${stackName}-ses-events`,
+      },
+    );
+
+    new CfnConfigurationSetEventDestination(
+      this,
+      `${stackName}-SesEventDestination`,
+      {
+        configurationSetName: sesConfigSet.ref,
+        eventDestination: {
+          name: `${stackName}-ses-to-sns`,
+          enabled: true,
+          matchingEventTypes: [
+            'bounce',
+            'complaint',
+            'reject',
+            'delivery',
+            'deliveryDelay',
+          ],
+          snsDestination: {
+            topicArn: this.alertTopic.topicArn,
+          },
+        },
+      },
+    );
+
+    // ── EventBridge Rule: Amplify Build Failures ──────────
+    new Rule(this, `${stackName}-AmplifyBuildFailRule`, {
+      ruleName: `${stackName}-Amplify-Build-Fail`,
+      description: 'Captures Amplify build failures and sends alerts',
+      eventPattern: {
+        source: ['aws.amplify'],
+        detailType: ['Amplify Deployment Status Change'],
+        detail: {
+          appId: [amplifyAppId],
+          jobStatus: ['FAILED'],
+        },
+      } as EventPattern,
+      targets: [new SnsTopic(this.alertTopic)],
+    });
 
     // Alarms overview
     this.dashboard.addWidgets(

--- a/packages/notifications/src/domain/alarm-parser.test.ts
+++ b/packages/notifications/src/domain/alarm-parser.test.ts
@@ -131,4 +131,115 @@ describe('parseAlarmMessage', () => {
     );
     expect(result.service).toBe('AWS/CustomNamespace');
   });
+
+  it('parses Amplify FAILED build event as CRITICAL', () => {
+    const event = JSON.stringify({
+      source: 'aws.amplify',
+      'detail-type': 'Amplify Deployment Status Change',
+      time: '2026-04-17T12:00:00Z',
+      detail: {
+        appId: 'd1nzvcjpfquip1',
+        branchName: 'main',
+        jobId: '42',
+        jobStatus: 'FAILED',
+      },
+    });
+    const result = parseAlarmMessage(event, 'https://dashboard.example.com');
+    expect(result.severity).toBe('CRITICAL');
+    expect(result.alarmName).toBe('Amplify Build FAILED');
+    expect(result.service).toBe('Amplify Hosting');
+    expect(result.description).toContain('branch "main"');
+    expect(result.description).toContain('42');
+  });
+
+  it('parses Amplify SUCCEED build event as INFO', () => {
+    const event = JSON.stringify({
+      source: 'aws.amplify',
+      'detail-type': 'Amplify Deployment Status Change',
+      time: '2026-04-17T12:05:00Z',
+      detail: {
+        appId: 'd1nzvcjpfquip1',
+        branchName: 'main',
+        jobId: '42',
+        jobStatus: 'SUCCEED',
+      },
+    });
+    const result = parseAlarmMessage(event, '');
+    expect(result.severity).toBe('INFO');
+    expect(result.alarmName).toBe('Amplify Build SUCCEED');
+  });
+
+  it('parses Amplify STARTED build event as INFO', () => {
+    const event = JSON.stringify({
+      source: 'aws.amplify',
+      'detail-type': 'Amplify Deployment Status Change',
+      time: '2026-04-17T12:00:00Z',
+      detail: {
+        appId: 'd1nzvcjpfquip1',
+        branchName: 'main',
+        jobId: '42',
+        jobStatus: 'STARTED',
+      },
+    });
+    const result = parseAlarmMessage(event, '');
+    expect(result.severity).toBe('INFO');
+  });
+
+  it('parses SES Bounce event as WARNING', () => {
+    const event = JSON.stringify({
+      eventType: 'Bounce',
+      mail: {
+        timestamp: '2026-04-17T12:00:00Z',
+        source: 'noreply@migudev.com',
+        destination: ['user@example.com'],
+        messageId: 'msg-123',
+      },
+      bounce: {
+        bounceType: 'Permanent',
+        bounceSubType: 'General',
+        bouncedRecipients: [{ emailAddress: 'user@example.com' }],
+      },
+    });
+    const result = parseAlarmMessage(event, '');
+    expect(result.severity).toBe('WARNING');
+    expect(result.alarmName).toBe('SES Bounce');
+    expect(result.service).toBe('SES Email');
+    expect(result.description).toContain('Permanent/General');
+    expect(result.description).toContain('user@example.com');
+  });
+
+  it('parses SES Complaint event as WARNING', () => {
+    const event = JSON.stringify({
+      eventType: 'Complaint',
+      mail: {
+        timestamp: '2026-04-17T12:00:00Z',
+        source: 'noreply@migudev.com',
+        destination: ['user@example.com'],
+        messageId: 'msg-456',
+      },
+      complaint: {
+        complainedRecipients: [{ emailAddress: 'user@example.com' }],
+        complaintFeedbackType: 'abuse',
+      },
+    });
+    const result = parseAlarmMessage(event, '');
+    expect(result.severity).toBe('WARNING');
+    expect(result.alarmName).toBe('SES Complaint');
+    expect(result.description).toContain('abuse');
+  });
+
+  it('parses SES Delivery event as INFO', () => {
+    const event = JSON.stringify({
+      eventType: 'Delivery',
+      mail: {
+        timestamp: '2026-04-17T12:00:00Z',
+        source: 'noreply@migudev.com',
+        destination: ['user@example.com'],
+        messageId: 'msg-789',
+      },
+    });
+    const result = parseAlarmMessage(event, '');
+    expect(result.severity).toBe('INFO');
+    expect(result.alarmName).toBe('SES Delivery');
+  });
 });

--- a/packages/notifications/src/domain/alarm-parser.ts
+++ b/packages/notifications/src/domain/alarm-parser.ts
@@ -1,7 +1,9 @@
 import type {
   AlertPayload,
   AlertSeverity,
+  AmplifyBuildEvent,
   CloudWatchAlarmMessage,
+  SesEventMessage,
 } from './types';
 
 const NAMESPACE_TO_SERVICE: Record<string, string> = {
@@ -36,11 +38,86 @@ function resolveService(alarm: CloudWatchAlarmMessage): string {
   return base;
 }
 
+function isAmplifyBuildEvent(parsed: unknown): parsed is AmplifyBuildEvent {
+  return (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'source' in parsed &&
+    (parsed as AmplifyBuildEvent).source === 'aws.amplify'
+  );
+}
+
+function isSesEvent(parsed: unknown): parsed is SesEventMessage {
+  return (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'eventType' in parsed &&
+    'mail' in parsed
+  );
+}
+
+function parseAmplifyEvent(
+  event: AmplifyBuildEvent,
+  dashboardUrl: string,
+): AlertPayload {
+  const { appId, branchName, jobId, jobStatus } = event.detail;
+  return {
+    alarmName: `Amplify Build ${jobStatus}`,
+    severity: jobStatus === 'FAILED' ? 'CRITICAL' : 'INFO',
+    service: 'Amplify Hosting',
+    description: `Build ${jobId} on branch "${branchName}" (app: ${appId}) status: ${jobStatus}`,
+    timestamp: event.time,
+    dashboardUrl,
+  };
+}
+
+function parseSesEvent(
+  event: SesEventMessage,
+  dashboardUrl: string,
+): AlertPayload {
+  const { eventType, mail } = event;
+  const severity: AlertSeverity =
+    eventType === 'Bounce' || eventType === 'Complaint' ? 'WARNING' : 'INFO';
+
+  let description = `SES ${eventType} for message ${mail.messageId} to ${mail.destination.join(', ')}`;
+  if (event.bounce) {
+    const recipients = event.bounce.bouncedRecipients
+      .map((r) => r.emailAddress)
+      .join(', ');
+    description = `${event.bounce.bounceType}/${event.bounce.bounceSubType} bounce for: ${recipients}`;
+  }
+  if (event.complaint) {
+    const recipients = event.complaint.complainedRecipients
+      .map((r) => r.emailAddress)
+      .join(', ');
+    description = `Complaint (${event.complaint.complaintFeedbackType ?? 'unknown'}) from: ${recipients}`;
+  }
+
+  return {
+    alarmName: `SES ${eventType}`,
+    severity,
+    service: 'SES Email',
+    description,
+    timestamp: mail.timestamp,
+    dashboardUrl,
+  };
+}
+
 export function parseAlarmMessage(
   raw: string,
   dashboardUrl: string,
 ): AlertPayload {
-  const alarm = JSON.parse(raw) as CloudWatchAlarmMessage;
+  const parsed = JSON.parse(raw) as unknown;
+
+  if (isAmplifyBuildEvent(parsed)) {
+    return parseAmplifyEvent(parsed, dashboardUrl);
+  }
+
+  if (isSesEvent(parsed)) {
+    return parseSesEvent(parsed, dashboardUrl);
+  }
+
+  const alarm = parsed as CloudWatchAlarmMessage;
   return {
     alarmName: alarm.AlarmName,
     severity: resolveSeverity(alarm.Trigger.MetricName),

--- a/packages/notifications/src/domain/alarm-parser.ts
+++ b/packages/notifications/src/domain/alarm-parser.ts
@@ -38,21 +38,33 @@ function resolveService(alarm: CloudWatchAlarmMessage): string {
   return base;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 function isAmplifyBuildEvent(parsed: unknown): parsed is AmplifyBuildEvent {
+  if (!isRecord(parsed)) return false;
+  const detail = parsed.detail;
   return (
-    typeof parsed === 'object' &&
-    parsed !== null &&
-    'source' in parsed &&
-    (parsed as AmplifyBuildEvent).source === 'aws.amplify'
+    parsed.source === 'aws.amplify' &&
+    typeof parsed['detail-type'] === 'string' &&
+    typeof parsed.time === 'string' &&
+    isRecord(detail) &&
+    typeof detail.appId === 'string' &&
+    typeof detail.branchName === 'string' &&
+    typeof detail.jobId === 'string' &&
+    typeof detail.jobStatus === 'string'
   );
 }
 
 function isSesEvent(parsed: unknown): parsed is SesEventMessage {
+  if (!isRecord(parsed)) return false;
+  const mail = parsed.mail;
   return (
-    typeof parsed === 'object' &&
-    parsed !== null &&
-    'eventType' in parsed &&
-    'mail' in parsed
+    typeof parsed.eventType === 'string' &&
+    isRecord(mail) &&
+    typeof mail.messageId === 'string' &&
+    Array.isArray(mail.destination)
   );
 }
 

--- a/packages/notifications/src/domain/types.ts
+++ b/packages/notifications/src/domain/types.ts
@@ -14,6 +14,37 @@ export interface CloudWatchAlarmMessage {
   };
 }
 
+export interface AmplifyBuildEvent {
+  source: 'aws.amplify';
+  'detail-type': 'Amplify Deployment Status Change';
+  detail: {
+    appId: string;
+    branchName: string;
+    jobId: string;
+    jobStatus: 'FAILED' | 'SUCCEED' | 'STARTED';
+  };
+  time: string;
+}
+
+export interface SesEventMessage {
+  eventType: 'Bounce' | 'Complaint' | 'Reject' | 'Delivery' | 'DeliveryDelay';
+  mail: {
+    timestamp: string;
+    source: string;
+    destination: string[];
+    messageId: string;
+  };
+  bounce?: {
+    bounceType: string;
+    bounceSubType: string;
+    bouncedRecipients: Array<{ emailAddress: string }>;
+  };
+  complaint?: {
+    complainedRecipients: Array<{ emailAddress: string }>;
+    complaintFeedbackType?: string;
+  };
+}
+
 export interface SNSEvent {
   Records: Array<{
     Sns: {
@@ -24,7 +55,7 @@ export interface SNSEvent {
   }>;
 }
 
-export type AlertSeverity = 'CRITICAL' | 'WARNING';
+export type AlertSeverity = 'CRITICAL' | 'WARNING' | 'INFO';
 
 export interface AlertPayload {
   alarmName: string;

--- a/packages/notifications/src/infrastructure/ses-sender.ts
+++ b/packages/notifications/src/infrastructure/ses-sender.ts
@@ -53,10 +53,13 @@ export async function sendAlertEmail(
   const body = replacePlaceholders(html, payload);
   const subject = `[${payload.severity}] ${payload.alarmName} — ${payload.service}`;
 
+  const configSetName = process.env['SES_CONFIGURATION_SET_NAME'];
+
   await clients.ses.send(
     new SendEmailCommand({
       Source: fromEmail,
       Destination: { ToAddresses: [toEmail] },
+      ...(configSetName && { ConfigurationSetName: configSetName }),
       Message: {
         Subject: { Data: subject, Charset: 'UTF-8' },
         Body: {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,6 +93,7 @@ minimumReleaseAge: 1440
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - react-native-worklets
+  - semver
 blockExoticSubdeps: true
 strictDepBuilds: true
 verifyStoreIntegrity: true


### PR DESCRIPTION
## Description

### Core changes

- Standardized stage-aware Lambda naming across Cognito triggers, API Lambdas, and the notifications Lambda to keep deployed resources predictable per environment.
- Added explicit CloudWatch log groups with 90-day retention for Cognito triggers, API Lambdas, and the notifications Lambda.
- Expanded the monitoring stack with a CloudWatch Logs Insights widget for Cognito trigger errors, SES event forwarding to the alert SNS topic, and Amplify deployment status notifications routed through the same alert flow.
- Updated the notifications parser so the alert pipeline can format CloudWatch alarms, Amplify deployment events, and SES delivery and feedback events consistently.

### Schema changes

- None.

### Minor changes

- Passed `STAGE` through the v1, v2, and v3 stack factories so resource names stay aligned with the target environment.
- Added `semver` to `trustPolicyExclude` in `pnpm-workspace.yaml`.

## Screenshots/Recordings

Not applicable.

## How to Test

<!-- Provide step-by-step instructions on how to test this PR manually. Include expected results where applicable. -->

1. Run `pnpm --filter @infra test -- --runInBand monitoring-stack cognito-stack lambda-users-stack lambda-expenses-stack lambda-documents-stack lambda-currencies-stack`.
   Expected result: all 6 test suites pass.
2. Run `pnpm --filter @packages/notifications test -- --runInBand alarm-parser index`.
   Expected result: all 2 test suites pass.
3. Deploy or synthesize the affected stacks with `STAGE=dev` and confirm the Lambda functions are named with the `fm-dev-*` convention and their log groups exist with a 90-day retention policy.
4. Open the CloudWatch dashboard and confirm the `Recent Cognito Trigger Errors` Logs Insights widget is present.
5. Trigger a failed Amplify deployment or publish a representative SES event through the alert flow and confirm the notification Lambda emits a formatted alert without breaking the existing CloudWatch alarm path.

## Checklist

- [x] The PR description includes clear instructions on how to test the implementation manually.

##### Added Tests?

- [x] yes
  - [x] Verified that this PR is not creating duplicate use cases
  - [x] All edge cases described in the acceptance criteria are covered, and tests have clear and descriptive names
- [ ] no, because they aren't needed
- [ ] no, because I need help

_Override these when needed._

<!-- START OVERRIDES -->

```sh

```

<!-- END OVERRIDES -->
