### PR TITLE
fix: AppSync Events WebSocket protocol for AI chat realtime

### DIFF
--- a/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.test.ts
+++ b/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.test.ts
@@ -8,14 +8,14 @@ import type { ChatEvent } from '@features/dashboard/domain/services/chat-event';
 class StubSocket {
   static last: StubSocket | undefined;
   url: string;
-  protocols?: string;
+  protocols?: string | string[];
   onopen: ((this: WebSocket, ev: Event) => unknown) | null = null;
   onclose: ((this: WebSocket, ev: CloseEvent) => unknown) | null = null;
   onerror: ((this: WebSocket, ev: Event) => unknown) | null = null;
   onmessage: ((this: WebSocket, ev: MessageEvent) => unknown) | null = null;
   sent: string[] = [];
 
-  constructor(url: string | URL, protocols?: string) {
+  constructor(url: string | URL, protocols?: string | string[]) {
     this.url = String(url);
     this.protocols = protocols;
     StubSocket.last = this;
@@ -71,7 +71,27 @@ describe('AppSyncEventsClient', () => {
     expect(ws).toBeDefined();
     expect(ws.url).toContain('wss://');
     expect(ws.url).toContain('/event/realtime');
-    expect(ws.protocols).toBe('aws-appsync-event-ws');
+    // Auth must NOT be in the query string (that's the legacy GraphQL protocol).
+    expect(ws.url).not.toContain('?header=');
+
+    // Events API carries auth in the subprotocols: the constant marker plus
+    // `header-<base64url(auth)>`.
+    const protocols = ws.protocols as string[];
+    expect(Array.isArray(protocols)).toBe(true);
+    expect(protocols[0]).toBe('aws-appsync-event-ws');
+    expect(protocols[1]).toMatch(/^header-/);
+    const decoded = JSON.parse(
+      Buffer.from(
+        protocols[1]!
+          .replace('header-', '')
+          .replace(/-/g, '+')
+          .replace(/_/g, '/'),
+        'base64',
+      ).toString('utf-8'),
+    ) as Record<string, string>;
+    expect(decoded.Authorization).toBe('mock-id-token');
+    // host must be the HTTP endpoint domain, not the realtime one.
+    expect(decoded.host).toBe('example.appsync-api.us-east-1.amazonaws.com');
 
     ws.simulateOpen();
     expect(JSON.parse(ws.sent[0]!)).toEqual({ type: 'connection_init' });
@@ -81,7 +101,7 @@ describe('AppSyncEventsClient', () => {
     expect(subscribeMsg.type).toBe('subscribe');
     expect(subscribeMsg.channel).toBe('/chat/user-1/responses');
     expect(subscribeMsg.authorization).toEqual(
-      expect.objectContaining({ authorization: 'mock-id-token' }),
+      expect.objectContaining({ Authorization: 'mock-id-token' }),
     );
 
     ws.simulateMessage({ type: 'subscribe_success' });

--- a/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.ts
+++ b/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.ts
@@ -16,24 +16,25 @@ export interface AppSyncEventsConfig {
 interface InternalMessage {
   type?: string;
   errors?: unknown;
-  event?: string;
+  event?: string | string[];
   id?: string;
 }
 
-const AUTH_HEADER_NAME = 'authorization';
+const EVENT_WS_SUBPROTOCOL = 'aws-appsync-event-ws';
 
 /**
  * Minimal AppSync Events WebSocket client.
  *
- * AppSync Events uses two short-lived JSON messages on top of a single
- * WebSocket:
- *   1. The client opens the socket with an `?header=...&payload=...` query
- *      string carrying a SigV4-style auth header (base64-encoded JSON).
- *   2. The client sends `{type: 'connection_init'}` and waits for `connection_ack`.
- *   3. The client sends a `subscribe` with the channel — server pushes
- *      `data` messages we forward to the listener.
+ * Per the Events API protocol, auth travels in a WebSocket SUBPROTOCOL
+ * (browsers can't set custom headers), NOT in the query string:
+ *   1. Open the socket against the realtime endpoint with two subprotocols:
+ *      `aws-appsync-event-ws` and `header-<base64url(authObject)>`. The auth
+ *      object's `host` MUST be the HTTP endpoint domain (not the realtime one).
+ *   2. Send `{type: 'connection_init'}` and wait for `connection_ack`.
+ *   3. Send a `subscribe` with the channel + the same authorization object —
+ *      the server pushes `data` messages we forward to the listener.
  *
- * @see https://docs.aws.amazon.com/appsync/latest/eventapi/event-api-protocol.html
+ * @see https://docs.aws.amazon.com/appsync/latest/eventapi/event-api-websocket-protocol.html
  */
 export class AppSyncEventsClient {
   private socket: WebSocket | null = null;
@@ -53,16 +54,23 @@ export class AppSyncEventsClient {
       throw new Error('Missing Cognito token for AppSync Events subscription');
     }
 
+    // The auth object's `host` must be the HTTP endpoint domain, even though
+    // we connect to the realtime endpoint. For standard AppSync domains that
+    // means swapping the subdomain; for custom domains both share a host so
+    // the replace is a no-op.
+    const host = this.config.realtimeDns.replace(
+      'appsync-realtime-api',
+      'appsync-api',
+    );
     const authHeader = {
-      host: this.config.realtimeDns,
-      [AUTH_HEADER_NAME]: token,
+      host,
+      Authorization: token,
     };
-    const encodedHeader = base64UrlEncode(JSON.stringify(authHeader));
-    const encodedPayload = base64UrlEncode('{}');
-    const url = `wss://${this.config.realtimeDns}/event/realtime?header=${encodedHeader}&payload=${encodedPayload}`;
+    const url = `wss://${this.config.realtimeDns}/event/realtime`;
+    const authSubprotocol = `header-${base64UrlEncode(JSON.stringify(authHeader))}`;
 
     await new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(url, 'aws-appsync-event-ws');
+      const ws = new WebSocket(url, [EVENT_WS_SUBPROTOCOL, authSubprotocol]);
       this.socket = ws;
 
       ws.onopen = () => {
@@ -137,15 +145,18 @@ export class AppSyncEventsClient {
 
   private handleData(parsed: InternalMessage): void {
     if (!this.listener) return;
-    // Event APIs deliver `event` as a stringified JSON payload.
-    const eventStr =
-      typeof parsed.event === 'string' ? parsed.event : undefined;
-    if (!eventStr) return;
-    try {
-      const event = JSON.parse(eventStr) as ChatEvent;
-      this.listener(event);
-    } catch (err) {
-      this.config.onError?.(err);
+    // Event APIs deliver `event` as a stringified JSON payload (or, in batch
+    // deliveries, an array of them). Normalize to an array and forward each.
+    const raw = parsed.event;
+    const eventStrings =
+      typeof raw === 'string' ? [raw] : Array.isArray(raw) ? raw : [];
+    for (const eventStr of eventStrings) {
+      try {
+        const event = JSON.parse(eventStr) as ChatEvent;
+        this.listener(event);
+      } catch (err) {
+        this.config.onError?.(err);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes the AI chat real-time delivery: opening the drawer showed "Something went wrong" and sent messages stayed in "processing" forever. Root cause was the AppSync Events WebSocket client using the **legacy GraphQL subscriptions handshake** instead of the Events API protocol, so the connection was rejected and responses never reached the client. Verified against the [official Events API WebSocket protocol docs](https://docs.aws.amazon.com/appsync/latest/eventapi/event-api-websocket-protocol.html).

The backend was already healthy — Step Functions executions ran `SUCCEEDED` and `save-and-publish` published to AppSync; the break was 100% client-side.

### Core Changes

In `client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.ts`:

- **Auth via subprotocol, not query string.** Events API requires auth in a WebSocket subprotocol (`header-<base64url(auth)>`) alongside `aws-appsync-event-ws`. The old code passed it as `?header=&payload=` (the GraphQL realtime scheme), which AppSync ignored → connection rejected.
- **`host` = HTTP endpoint domain.** The auth object's `host` must be the `appsync-api` domain even when connecting to the `appsync-realtime-api` endpoint (per the docs). Derived from the realtime DNS (no-op for custom domains).
- **`Authorization` key** (capitalized) for Cognito User Pool auth.
- `data.event` handling tolerates both a string and an array payload.

### API / Data Changes

None. No infra changes — client-only. Confirmed the Event API auth config is already correct (connect + subscribe = Cognito User Pools, publish = IAM).

## Type of Change

- [ ] Feature (new functionality)
- [x] Bug fix (non-breaking fix for an issue)
- [ ] Refactor (code improvement with no behavior change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / maintenance

## How to Test

1. Merge → Amplify rebuilds `main` (the infra/env race is no longer a factor; env vars are already provisioned).
2. Open the dashboard at the dev URL, open the AI Chat drawer → it should connect with no error.
3. Send a QUERY ("¿Cuánto gasté este mes?") → "Procesando..." then the assistant answer arrives over the WebSocket.
4. Send a CREATE ("Pagué 80000 pesos de mercado ayer") → preview with Confirmar/Cancelar; confirm → confirmation message arrives.

Expected: no "Something went wrong" on open; responses delivered in real time.

## Checklist

- [x] PR description includes clear testing instructions
- [x] Self-reviewed the code for readability and correctness
- [x] No new warnings in format, lint, typecheck, or test
- [ ] PR has the correct type label assigned

### Tests

- [x] Added or updated tests covering the changes
  - [x] Not creating duplicate test cases
  - [x] All edge cases from acceptance criteria are covered
  - [x] Tests have clear and descriptive names

### Project Structure

- [x] New services are placed in `services/`
- [x] New client features are placed in `client/packages/features/`
- [x] New shared packages are placed in `packages/`
- [x] New CDK stacks follow versioning (`infra/lib/versions/`)
- [x] Shared config changes are reflected across dependent packages

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
