### PR TITLE
feat: conversation context + currency-aware clarifications for AI chat

### DIFF
--- a/infra/lib/versions/v2/step-functions-chat-stack.ts
+++ b/infra/lib/versions/v2/step-functions-chat-stack.ts
@@ -206,7 +206,7 @@ export class StepFunctionsChatStack extends BaseStack {
       model: novaMicro,
       body: novaBody(
         PROMPTS.intent.system,
-        '$.content',
+        "States.Format('Historial de la conversación: {} === Último mensaje del usuario: {}', $.history, $.content)",
         PROMPTS.intent.maxTokens,
       ),
       resultSelector: {
@@ -225,7 +225,7 @@ export class StepFunctionsChatStack extends BaseStack {
       model: novaLite,
       body: novaBody(
         PROMPTS.extractSqlParams.system,
-        "States.Format('Fecha actual: {}. Mensaje: {}', $$.Execution.StartTime, $.content)",
+        "States.Format('Fecha actual: {}. Historial: {} === Mensaje actual: {}', $$.Execution.StartTime, $.history, $.content)",
         PROMPTS.extractSqlParams.maxTokens,
       ),
       resultSelector: {
@@ -265,7 +265,7 @@ export class StepFunctionsChatStack extends BaseStack {
       model: novaLite,
       body: novaBody(
         PROMPTS.extractExpenseFields.system,
-        "States.Format('Fecha actual: {}. Mensaje: {}', $$.Execution.StartTime, $.content)",
+        "States.Format('Fecha actual: {}. Historial: {} === Mensaje actual: {}', $$.Execution.StartTime, $.history, $.content)",
         PROMPTS.extractExpenseFields.maxTokens,
       ),
       resultSelector: {
@@ -362,7 +362,7 @@ export class StepFunctionsChatStack extends BaseStack {
         model: claudeHaiku,
         body: claudeBody(
           PROMPTS.clarification.system,
-          "States.Format('Faltan estos campos: {}. Mensaje original: {}', States.JsonToString($.validation.missing), $.content)",
+          "States.Format('Faltan estos campos: {}. Monedas disponibles: {}. Mensaje original: {}', States.JsonToString($.validation.missing), States.JsonToString($.validation.availableCurrencies), $.content)",
           PROMPTS.clarification.maxTokens,
           PROMPTS.clarification.temperature,
         ),

--- a/packages/prompts/src/chat/extraction.ts
+++ b/packages/prompts/src/chat/extraction.ts
@@ -24,6 +24,7 @@ Dada la frase del usuario y la fecha actual, devolvé un OBJETO JSON con esta fo
 }
 - "metrics" si pregunta por totales, sumas, promedios, "cuánto"; "list" si pide un listado o detalle.
 - Resolvé fechas relativas usando la fecha actual provista (mes pasado, esta semana, hoy, ayer).
+- Si se te provee historial, resolvé preguntas de seguimiento en contexto (ej: tras "¿cuánto gasté este mes?", un "¿y el mes pasado?" hereda el tipo de consulta y ajusta sólo las fechas).
 - Omití campos que no aparezcan. Devolvé ÚNICAMENTE el JSON, sin markdown ni comentarios.`;
 
 export const EXTRACT_EXPENSE_FIELDS_SYSTEM_PROMPT = `Eres un extractor de campos para crear un gasto.
@@ -36,5 +37,6 @@ Dada la frase del usuario, devolvé un OBJETO JSON con esta forma:
   "categoryName": string opcional (categoría libre),
   "date": string opcional ISO (YYYY-MM-DD sólo si el mensaje menciona una fecha; resolvé fechas relativas con la fecha actual provista)
 }
-- Omití campos que no aparezcan en el mensaje.
+- Si se te provee historial de la conversación, FUSIONÁ los datos: combiná lo que el usuario ya dio en mensajes anteriores con lo que aporta el mensaje actual. Ej: si antes dijo "gasto de 25 USD, egreso" y ahora responde "hagámoslo en COP", devolvé { "value": 25, "currencyCode": "COP", "expenseTypeName": "egreso", ... }.
+- Omití campos que no aparezcan ni en el mensaje ni en el historial.
 - Devolvé ÚNICAMENTE el JSON, sin markdown ni explicación.`;

--- a/packages/prompts/src/chat/intent.ts
+++ b/packages/prompts/src/chat/intent.ts
@@ -15,4 +15,8 @@ Ejemplos:
 "Mostrame mis gastos de mayo" → QUERY
 "Compré un teclado por 80 USD" → CREATE
 "Hola, ¿qué podés hacer?" → UNKNOWN
+Si se te provee historial de la conversación, interpretá el ÚLTIMO mensaje del usuario EN CONTEXTO:
+- Si el asistente venía pidiendo datos para registrar un gasto y el usuario responde con un dato (una moneda, un monto, una fecha, "sí", "hagámoslo en USD", "en dólares"), la intención sigue siendo CREATE.
+- Si el usuario venía consultando y hace una pregunta de seguimiento ("¿y el mes pasado?", "¿y en comida?"), la intención sigue siendo QUERY.
+- Sólo usá UNKNOWN cuando, incluso con el contexto, el mensaje no encaje en consultar ni registrar.
 Respondé sólo con la palabra, sin explicación, sin puntuación, sin comillas.`;

--- a/packages/prompts/src/chat/responses.ts
+++ b/packages/prompts/src/chat/responses.ts
@@ -25,6 +25,11 @@ Tono neutro, sin emoji negativo.`;
 
 export const CLARIFICATION_SYSTEM_PROMPT = `Eres un asistente que pide los datos faltantes para registrar un gasto.
 Dado el listado de campos faltantes, devolvé una sola pregunta en español, natural y conversacional, pidiendo esos datos.
-Si falta más de un campo, agrupalos en una única pregunta clara.`;
+Si falta más de un campo, agrupalos en una única pregunta clara.
+Si entre los faltantes está la moneda y se te provee una lista de monedas disponibles, ofrecé ÚNICAMENTE esas monedas (ej: "¿en qué moneda? Disponibles: COP, EUR, MXN") y NUNCA sugieras una que no esté en la lista.`;
 
-export const UNKNOWN_SYSTEM_PROMPT = `Eres un asistente que pide al usuario que reformule su mensaje en español, en una oración.`;
+export const UNKNOWN_SYSTEM_PROMPT = `Eres un asistente de finanzas personales. El usuario escribió algo que no pudiste interpretar como registrar un gasto ni como consultar sus gastos.
+Respondé en español, cálido y breve (1-2 oraciones), e invitá al usuario a:
+1. registrar un gasto (ej: "Gasté 20000 en taxi"), o
+2. consultar sus gastos (ej: "¿Cuánto gasté este mes?").
+No te disculpes en exceso ni le pidas que "reformule"; dale ejemplos concretos.`;

--- a/services/chat/src/application/use-cases/confirm-pending-expense.use-case.test.ts
+++ b/services/chat/src/application/use-cases/confirm-pending-expense.use-case.test.ts
@@ -6,6 +6,7 @@ import type { WorkflowCallbackService } from '@services/chat/domain/services/wor
 function makeMockMessageRepo(): jest.Mocked<ChatMessageRepository> {
   return {
     create: jest.fn(),
+    findRecentBySession: jest.fn(),
     findPendingByTaskToken: jest.fn(),
     updateTaskTokenStatus: jest.fn(),
   };

--- a/services/chat/src/application/use-cases/save-assistant-message.use-case.test.ts
+++ b/services/chat/src/application/use-cases/save-assistant-message.use-case.test.ts
@@ -7,6 +7,7 @@ import type { EventPublisherService } from '@services/chat/domain/services/event
 function makeMessageRepo(): jest.Mocked<ChatMessageRepository> {
   return {
     create: jest.fn(),
+    findRecentBySession: jest.fn(),
     findPendingByTaskToken: jest.fn(),
     updateTaskTokenStatus: jest.fn(),
   };

--- a/services/chat/src/application/use-cases/send-message.use-case.test.ts
+++ b/services/chat/src/application/use-cases/send-message.use-case.test.ts
@@ -16,6 +16,7 @@ function makeMockSessionRepo(): jest.Mocked<ChatSessionRepository> {
 function makeMockMessageRepo(): jest.Mocked<ChatMessageRepository> {
   return {
     create: jest.fn(),
+    findRecentBySession: jest.fn().mockResolvedValue([]),
     findPendingByTaskToken: jest.fn(),
     updateTaskTokenStatus: jest.fn(),
   };
@@ -173,8 +174,46 @@ describe('SendMessageUseCase', () => {
       userId: UID,
       userEmail: EMAIL,
       content: 'Gasté $45 en la cena',
+      history: '',
     });
     expect(result.execution).toEqual(mockExecution);
+  });
+
+  it('passes a formatted transcript of prior messages as history', async () => {
+    const sessionRepo = makeMockSessionRepo();
+    const messageRepo = makeMockMessageRepo();
+    const starter = makeMockStarter();
+    sessionRepo.findByIdAndUserUid.mockResolvedValue(mockSession);
+    messageRepo.create.mockResolvedValue(mockUserMessage);
+    starter.start.mockResolvedValue(mockExecution);
+    // Prior turns (oldest → newest), loaded BEFORE the current message.
+    messageRepo.findRecentBySession.mockResolvedValue([
+      {
+        ...mockUserMessage,
+        role: 'user',
+        content: 'Quiero registrar un gasto de 25',
+      },
+      { ...mockUserMessage, role: 'assistant', content: '¿En qué moneda?' },
+    ]);
+
+    const useCase = new SendMessageUseCase(sessionRepo, messageRepo, starter);
+    await useCase.execute(
+      { sessionId: 'session-1', content: 'en COP' },
+      UID,
+      EMAIL,
+    );
+
+    // History is loaded for the session/user, before persisting the new message.
+    expect(messageRepo.findRecentBySession).toHaveBeenCalledWith(
+      'session-1',
+      UID,
+      expect.any(Number),
+    );
+    const startArg = starter.start.mock.calls[0]![0];
+    expect(startArg.history).toBe(
+      'Usuario: Quiero registrar un gasto de 25\nAsistente: ¿En qué moneda?',
+    );
+    expect(startArg.content).toBe('en COP');
   });
 
   it('forwards attachment metadata when present', async () => {

--- a/services/chat/src/application/use-cases/send-message.use-case.ts
+++ b/services/chat/src/application/use-cases/send-message.use-case.ts
@@ -24,6 +24,31 @@ export interface SendMessageResult {
   execution: StartChatWorkflowResult;
 }
 
+/** How many prior messages to feed the LLM as conversation context. */
+const HISTORY_LIMIT = 10;
+/** Cap each message in the history to keep the workflow input small. */
+const HISTORY_CONTENT_MAX = 500;
+
+const ROLE_LABEL: Record<string, string> = {
+  user: 'Usuario',
+  assistant: 'Asistente',
+  system: 'Sistema',
+};
+
+/**
+ * Formats recent messages (oldest → newest) into a compact transcript the
+ * intent/extraction prompts can reason over. Returns '' when there's none.
+ */
+export function formatHistory(messages: ChatMessage[]): string {
+  return messages
+    .map((m) => {
+      const label = ROLE_LABEL[m.role] ?? m.role;
+      const content = m.content.slice(0, HISTORY_CONTENT_MAX);
+      return `${label}: ${content}`;
+    })
+    .join('\n');
+}
+
 /**
  * Persists the user's message and starts the async chat workflow.
  *
@@ -51,6 +76,15 @@ export class SendMessageUseCase {
   ): Promise<SendMessageResult> {
     const session = await this.resolveSession(input.sessionId, uid, userEmail);
 
+    // Load prior turns BEFORE persisting the current message so the history
+    // is context for it (not including it).
+    const priorMessages = await this.messageRepository.findRecentBySession(
+      session.id,
+      uid,
+      HISTORY_LIMIT,
+    );
+    const history = formatHistory(priorMessages);
+
     const userMessage = await this.messageRepository.create(
       {
         session_id: session.id,
@@ -70,6 +104,7 @@ export class SendMessageUseCase {
       userId: uid,
       userEmail,
       content: input.content,
+      history,
       ...(input.attachmentS3Key !== undefined && {
         attachmentS3Key: input.attachmentS3Key,
       }),

--- a/services/chat/src/application/use-cases/send-message.use-case.ts
+++ b/services/chat/src/application/use-cases/send-message.use-case.ts
@@ -43,7 +43,12 @@ export function formatHistory(messages: ChatMessage[]): string {
   return messages
     .map((m) => {
       const label = ROLE_LABEL[m.role] ?? m.role;
-      const content = m.content.slice(0, HISTORY_CONTENT_MAX);
+      // Collapse newlines/whitespace so a multi-line message can't break the
+      // line-based "Role: ..." transcript structure the LLM reads.
+      const content = m.content
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, HISTORY_CONTENT_MAX);
       return `${label}: ${content}`;
     })
     .join('\n');

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
@@ -80,6 +80,9 @@ describe('ValidateExpenseFieldsUseCase', () => {
     expect(result.complete).toBe(false);
     expect(result.missing).toContain('descripción');
     expect(result.fields).toBeUndefined();
+    // Currency resolved, so it's not missing → no catalog query, empty list.
+    expect(result.availableCurrencies).toEqual([]);
+    expect(catalog.listCurrencyCodes).not.toHaveBeenCalled();
   });
 
   it('reports missing when value is zero or negative', async () => {

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
@@ -6,6 +6,7 @@ function makeMockCatalog(): jest.Mocked<CatalogLookupRepository> {
     findCurrencyIdByCode: jest.fn(),
     findExpenseTypeIdByName: jest.fn(),
     findCategoryIdByName: jest.fn(),
+    listCurrencyCodes: jest.fn().mockResolvedValue(['ARS', 'COP', 'EUR']),
   } as unknown as jest.Mocked<CatalogLookupRepository>;
 }
 
@@ -113,6 +114,9 @@ describe('ValidateExpenseFieldsUseCase', () => {
 
     expect(result.complete).toBe(false);
     expect(result.missing).toContain('moneda');
+    // The clarification path gets the real catalog currencies so it can offer
+    // valid options instead of re-suggesting the unsupported one.
+    expect(result.availableCurrencies).toEqual(['ARS', 'COP', 'EUR']);
   });
 
   it('reports missing currency when no currency was extracted at all', async () => {

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
@@ -23,6 +23,12 @@ export interface ValidateExpenseFieldsResult {
   fields?: ResolvedExpenseFields;
   /** When `complete` is false, the friendly names of what is missing. */
   missing: string[];
+  /**
+   * Valid currency codes from the catalog. Always populated when `complete`
+   * is false (the clarification path), so the clarification prompt can offer
+   * the real options instead of suggesting an unsupported one (e.g. USD).
+   */
+  availableCurrencies?: string[];
 }
 
 const FRIENDLY_LABELS = {
@@ -80,7 +86,13 @@ export class ValidateExpenseFieldsUseCase {
     }
 
     if (missing.length > 0) {
-      return { complete: false, missing };
+      // Always surface the catalog currencies on the clarification path so the
+      // prompt can offer real options (and never re-suggest an unsupported one
+      // like USD). The field is always present here, which also keeps the
+      // Step Functions `States.JsonToString($.validation.availableCurrencies)`
+      // reference valid.
+      const availableCurrencies = await this.catalogLookup.listCurrencyCodes();
+      return { complete: false, missing, availableCurrencies };
     }
 
     const fields: ResolvedExpenseFields = {

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
@@ -24,9 +24,10 @@ export interface ValidateExpenseFieldsResult {
   /** When `complete` is false, the friendly names of what is missing. */
   missing: string[];
   /**
-   * Valid currency codes from the catalog. Always populated when `complete`
-   * is false (the clarification path), so the clarification prompt can offer
-   * the real options instead of suggesting an unsupported one (e.g. USD).
+   * Valid currency codes from the catalog. Present (possibly empty) whenever
+   * `complete` is false, so the clarification prompt can offer the real
+   * options instead of suggesting an unsupported one (e.g. USD). Populated
+   * only when `moneda` is among the missing fields; `[]` otherwise.
    */
   availableCurrencies?: string[];
 }
@@ -86,12 +87,15 @@ export class ValidateExpenseFieldsUseCase {
     }
 
     if (missing.length > 0) {
-      // Always surface the catalog currencies on the clarification path so the
-      // prompt can offer real options (and never re-suggest an unsupported one
-      // like USD). The field is always present here, which also keeps the
-      // Step Functions `States.JsonToString($.validation.availableCurrencies)`
-      // reference valid.
-      const availableCurrencies = await this.catalogLookup.listCurrencyCodes();
+      // Surface the catalog currencies only when the currency is what's
+      // missing, so the prompt can offer real options (and never re-suggest an
+      // unsupported one like USD). Otherwise return an empty array — this
+      // avoids a needless query while keeping the field always present, which
+      // the Step Functions `States.JsonToString($.validation.availableCurrencies)`
+      // reference requires.
+      const availableCurrencies = missing.includes(FRIENDLY_LABELS.currency)
+        ? await this.catalogLookup.listCurrencyCodes()
+        : [];
       return { complete: false, missing, availableCurrencies };
     }
 

--- a/services/chat/src/domain/repositories/chat-message.repository.ts
+++ b/services/chat/src/domain/repositories/chat-message.repository.ts
@@ -19,6 +19,17 @@ export interface ChatMessageRepository {
   ): Promise<ChatMessage>;
 
   /**
+   * Returns the most recent messages of a session (oldest → newest) so the
+   * workflow can give the LLM conversation context for multi-turn flows
+   * (e.g. answering a clarification). Scoped to the owning user.
+   */
+  findRecentBySession(
+    sessionId: string,
+    uid: string,
+    limit: number,
+  ): Promise<ChatMessage[]>;
+
+  /**
    * Finds the assistant message that is currently holding a `pending`
    * task token. Used by the human-in-the-loop confirmation flow to look
    * up the workflow waiting on the user.

--- a/services/chat/src/domain/services/workflow-starter.service.ts
+++ b/services/chat/src/domain/services/workflow-starter.service.ts
@@ -9,6 +9,13 @@ export interface StartChatWorkflowInput {
   userId: string;
   userEmail: string;
   content: string;
+  /**
+   * Recent conversation transcript (oldest → newest, excluding the current
+   * message) injected into the intent/extraction prompts so multi-turn flows
+   * work — short replies are understood in context and CREATE fields
+   * accumulate across turns. Empty string for the first message of a session.
+   */
+  history: string;
   attachmentS3Key?: string;
   attachmentType?: 'image' | 'audio';
 }

--- a/services/chat/src/infrastructure/repositories/catalog-lookup.repository.ts
+++ b/services/chat/src/infrastructure/repositories/catalog-lookup.repository.ts
@@ -12,6 +12,14 @@ import { trace } from '@services/shared/infrastructure/decorators/trace';
 export class CatalogLookupRepository {
   constructor(private readonly dbService: DatabaseService) {}
 
+  @trace('Catalog:listCurrencyCodes')
+  async listCurrencyCodes(): Promise<string[]> {
+    const rows = await this.dbService.queryReadOnly<{ code: string }>(
+      `SELECT code FROM financial_management.currencies ORDER BY code ASC`,
+    );
+    return rows.map((r) => r.code);
+  }
+
   @trace('Catalog:findCurrencyIdByCode')
   async findCurrencyIdByCode(code: string): Promise<string | null> {
     const rows = await this.dbService.queryReadOnly<{ id: string }>(

--- a/services/chat/src/infrastructure/repositories/postgres-chat-message.repository.ts
+++ b/services/chat/src/infrastructure/repositories/postgres-chat-message.repository.ts
@@ -21,6 +21,27 @@ const RETURNING_COLUMNS = `id, session_id, role, content, attachment_s3_key, att
 export class PostgresChatMessageRepository implements ChatMessageRepository {
   constructor(private readonly dbService: DatabaseService) {}
 
+  @trace('ChatMessage:findRecentBySession')
+  async findRecentBySession(
+    sessionId: string,
+    uid: string,
+    limit: number,
+  ): Promise<ChatMessage[]> {
+    // Newest-first in SQL (so LIMIT keeps the latest), then reversed to
+    // chronological order for the LLM. Scoped to the owning user.
+    const rows = await this.dbService.queryReadOnly<ChatMessage>(
+      `SELECT ${MESSAGE_COLUMNS}
+       FROM financial_management.chat_messages m
+       JOIN financial_management.chat_sessions s ON m.session_id = s.id
+       JOIN financial_management.users u ON s.user_id = u.id
+       WHERE m.session_id = $1 AND u.uid = $2
+       ORDER BY m.created_at DESC
+       LIMIT $3`,
+      [sessionId, uid, limit],
+    );
+    return rows.reverse();
+  }
+
   @trace('ChatMessage:create')
   async create(
     input: CreateChatMessageInput,

--- a/services/chat/src/infrastructure/repositories/postgres-chat-message.repository.ts
+++ b/services/chat/src/infrastructure/repositories/postgres-chat-message.repository.ts
@@ -35,7 +35,7 @@ export class PostgresChatMessageRepository implements ChatMessageRepository {
        JOIN financial_management.chat_sessions s ON m.session_id = s.id
        JOIN financial_management.users u ON s.user_id = u.id
        WHERE m.session_id = $1 AND u.uid = $2
-       ORDER BY m.created_at DESC
+       ORDER BY m.created_at DESC, m.id DESC
        LIMIT $3`,
       [sessionId, uid, limit],
     );

--- a/services/chat/src/infrastructure/services/sfn-workflow-starter.service.test.ts
+++ b/services/chat/src/infrastructure/services/sfn-workflow-starter.service.test.ts
@@ -11,6 +11,7 @@ const INPUT = {
   userId: 'uid-1',
   userEmail: 'a@b.c',
   content: 'Hola',
+  history: '',
 };
 
 describe('SfnWorkflowStarter', () => {

--- a/services/chat/src/test/chat-messages.integration.test.ts
+++ b/services/chat/src/test/chat-messages.integration.test.ts
@@ -41,6 +41,46 @@ afterAll(async () => {
 });
 
 describe('PostgresChatMessageRepository — integration', () => {
+  describe('findRecentBySession', () => {
+    it('returns messages oldest → newest, scoped to the owning user', async () => {
+      await repo.create(
+        { session_id: session.id, role: 'user', content: 'primero' },
+        userA.email,
+      );
+      await repo.create(
+        { session_id: session.id, role: 'assistant', content: 'segundo' },
+        userA.email,
+      );
+      await repo.create(
+        { session_id: session.id, role: 'user', content: 'tercero' },
+        userA.email,
+      );
+
+      const recent = await repo.findRecentBySession(session.id, userA.uid, 10);
+      expect(recent.map((m) => m.content)).toEqual([
+        'primero',
+        'segundo',
+        'tercero',
+      ]);
+
+      // Another user cannot read this session's history.
+      expect(await repo.findRecentBySession(session.id, userB.uid, 10)).toEqual(
+        [],
+      );
+    });
+
+    it('keeps only the latest `limit` messages (still chronological)', async () => {
+      for (const c of ['m1', 'm2', 'm3', 'm4']) {
+        await repo.create(
+          { session_id: session.id, role: 'user', content: c },
+          userA.email,
+        );
+      }
+      const recent = await repo.findRecentBySession(session.id, userA.uid, 2);
+      expect(recent.map((m) => m.content)).toEqual(['m3', 'm4']);
+    });
+  });
+
   describe('create', () => {
     it('creates a user message with generated fields', async () => {
       const message = await repo.create(


### PR DESCRIPTION
## Description

Improves the AI chat conversational UX. After reviewing a real multi-turn session in dev (persisted in `chat_messages`), the bot felt broken: short replies to its own clarifications were classified as UNKNOWN ("Por favor, reformula tu mensaje…") and CREATE fields never accumulated across turns, so an expense could never be completed conversationally. Root cause: the workflow was **stateless per message** (each message = a fresh Step Functions execution classified/extracted in isolation, with no history).

All three fixes are deployed to dev and validated with real Step Functions executions.

### Core Changes

- **Conversation history (multi-turn context).** `send-message` loads the last 10 session messages (new `findRecentBySession` repo method) and passes a formatted transcript as `history` in the workflow input. The `ClassifyIntent`, `ExtractSqlParams` and `ExtractExpenseFields` prompts receive it via `States.Format`, so:
  - continuations like "hagámoslo en COP" are understood in context (stay CREATE instead of UNKNOWN), and
  - CREATE fields **merge across turns** — value/type from an earlier turn combine with name/currency from the reply (slot-filling).
- **Currency-aware clarification.** `validate-expense-fields` now returns the catalog currency codes (new `listCurrencyCodes`); the clarification prompt offers only real currencies (e.g. "Disponibles: ARS, COP, EUR, MXN, UYU") instead of re-suggesting an unsupported one like USD — which previously caused a dead-end loop.
- **Better UNKNOWN fallback.** Replaces "reformula tu mensaje" with a helpful message giving concrete examples (register an expense / query spending).

### API / Data Changes

- New `ChatMessageRepository.findRecentBySession(sessionId, uid, limit)` (port + Postgres impl, user-scoped).
- `StartChatWorkflowInput` gains a required `history: string`.
- `ValidateExpenseFieldsResult` gains `availableCurrencies?: string[]` (always set on the incomplete/clarification path).
- Prompt text changes in `@packages/prompts` → requires redeploying the StepFunctionsChat stack (done in dev).

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix (non-breaking fix for an issue)
- [ ] Refactor (code improvement with no behavior change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / maintenance

## How to Test

Validated in dev via real `fm-dev-chat-process` executions:

1. **Currency-aware**: "Quiero registrar un gasto, el monto es de 25 USD" → clarification asks "¿…en qué moneda? Disponibles: ARS, COP, EUR, MXN, UYU" (no longer suggests USD).
2. **Context + slot-filling**: follow-up "la cena en La Trattoria, hagámoslo en COP" (with prior turn in history) → intent=CREATE, extraction merges `value:25` + `egreso` (from history) with `name` + `COP` (current) → validation complete → reaches the HITL preview.
3. **UNKNOWN**: "hola, que tal todo" → "¡Hola! 👋 … Podés decirme 'Gasté 5000 en almuerzo' … o preguntarme '¿Cuánto gasté esta semana?'".

Browser E2E: open the AI Chat drawer and run the same multi-turn create flow end-to-end.

## Checklist

- [x] PR description includes clear testing instructions
- [x] Self-reviewed the code for readability and correctness
- [x] No new warnings in format, lint, typecheck, or test
- [ ] PR has the correct type label assigned

### Tests

- [x] Added or updated tests covering the changes
  - [x] Not creating duplicate test cases
  - [x] All edge cases from acceptance criteria are covered
  - [x] Tests have clear and descriptive names

### Project Structure

- [x] New services are placed in `services/`
- [x] New client features are placed in `client/packages/features/`
- [x] New shared packages are placed in `packages/`
- [x] New CDK stacks follow versioning (`infra/lib/versions/`)
- [x] Shared config changes are reflected across dependent packages

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
