### PR TITLE
feat: clearer chat clarifications and context-aware UNKNOWN fallback

### DIFF
--- a/infra/lib/versions/v2/step-functions-chat-stack.ts
+++ b/infra/lib/versions/v2/step-functions-chat-stack.ts
@@ -362,7 +362,7 @@ export class StepFunctionsChatStack extends BaseStack {
         model: claudeHaiku,
         body: claudeBody(
           PROMPTS.clarification.system,
-          "States.Format('Faltan estos campos: {}. Moneda no soportada: {}. Monedas disponibles: {}. Mensaje original: {}', States.JsonToString($.validation.missing), $.validation.unsupportedCurrency, States.JsonToString($.validation.availableCurrencies), $.content)",
+          'States.Format(\'Faltan estos campos: {}. Moneda no soportada: "{}". Monedas disponibles: {}. Mensaje original: {}\', States.JsonToString($.validation.missing), $.validation.unsupportedCurrency, States.JsonToString($.validation.availableCurrencies), $.content)',
           PROMPTS.clarification.maxTokens,
           PROMPTS.clarification.temperature,
         ),

--- a/infra/lib/versions/v2/step-functions-chat-stack.ts
+++ b/infra/lib/versions/v2/step-functions-chat-stack.ts
@@ -362,7 +362,7 @@ export class StepFunctionsChatStack extends BaseStack {
         model: claudeHaiku,
         body: claudeBody(
           PROMPTS.clarification.system,
-          "States.Format('Faltan estos campos: {}. Monedas disponibles: {}. Mensaje original: {}', States.JsonToString($.validation.missing), States.JsonToString($.validation.availableCurrencies), $.content)",
+          "States.Format('Faltan estos campos: {}. Moneda no soportada: {}. Monedas disponibles: {}. Mensaje original: {}', States.JsonToString($.validation.missing), $.validation.unsupportedCurrency, States.JsonToString($.validation.availableCurrencies), $.content)",
           PROMPTS.clarification.maxTokens,
           PROMPTS.clarification.temperature,
         ),
@@ -435,7 +435,7 @@ export class StepFunctionsChatStack extends BaseStack {
       model: claudeHaiku,
       body: claudeBody(
         PROMPTS.unknown.system,
-        "States.Format('Mensaje no entendido: {}', $.content)",
+        "States.Format('Historial: {} === Mensaje no entendido: {}', $.history, $.content)",
         PROMPTS.unknown.maxTokens,
         PROMPTS.unknown.temperature,
       ),

--- a/packages/prompts/src/chat/intent.ts
+++ b/packages/prompts/src/chat/intent.ts
@@ -17,6 +17,7 @@ Ejemplos:
 "Hola, ¿qué podés hacer?" → UNKNOWN
 Si se te provee historial de la conversación, interpretá el ÚLTIMO mensaje del usuario EN CONTEXTO:
 - Si el asistente venía pidiendo datos para registrar un gasto y el usuario responde con un dato (una moneda, un monto, una fecha, "sí", "hagámoslo en USD", "en dólares"), la intención sigue siendo CREATE.
+- Si el asistente venía pidiendo datos para registrar un gasto y el usuario hace referencia a datos que ya dio o se queja ("ya te lo dije", "como dije antes", "te lo pasé en el mensaje anterior"), la intención SIGUE siendo CREATE (no UNKNOWN): los datos están en el historial.
 - Si el usuario venía consultando y hace una pregunta de seguimiento ("¿y el mes pasado?", "¿y en comida?"), la intención sigue siendo QUERY.
 - Sólo usá UNKNOWN cuando, incluso con el contexto, el mensaje no encaje en consultar ni registrar.
 Respondé sólo con la palabra, sin explicación, sin puntuación, sin comillas.`;

--- a/packages/prompts/src/chat/responses.ts
+++ b/packages/prompts/src/chat/responses.ts
@@ -26,10 +26,13 @@ Tono neutro, sin emoji negativo.`;
 export const CLARIFICATION_SYSTEM_PROMPT = `Eres un asistente que pide los datos faltantes para registrar un gasto.
 Dado el listado de campos faltantes, devolvé una sola pregunta en español, natural y conversacional, pidiendo esos datos.
 Si falta más de un campo, agrupalos en una única pregunta clara.
-Si entre los faltantes está la moneda y se te provee una lista de monedas disponibles, ofrecé ÚNICAMENTE esas monedas (ej: "¿en qué moneda? Disponibles: COP, EUR, MXN") y NUNCA sugieras una que no esté en la lista.`;
+Si entre los faltantes está la moneda y se te provee una lista de monedas disponibles, ofrecé ÚNICAMENTE esas monedas (ej: "¿en qué moneda? Disponibles: COP, EUR, MXN") y NUNCA sugieras una que no esté en la lista.
+Si se te indica una "Moneda no soportada" no vacía, aclará amablemente que esa moneda NO está disponible y pedí que elija una de las disponibles (ej: "USD no está disponible; ¿usamos COP, EUR o MXN?"). No actúes como si el usuario no hubiera dado una moneda.`;
 
 export const UNKNOWN_SYSTEM_PROMPT = `Eres un asistente de finanzas personales. El usuario escribió algo que no pudiste interpretar como registrar un gasto ni como consultar sus gastos.
-Respondé en español, cálido y breve (1-2 oraciones), e invitá al usuario a:
+Si se te provee historial de la conversación, TENÉS contexto de lo que venían haciendo: úsalo. NUNCA digas que no tenés acceso a mensajes anteriores ni propongas "empezar de cero".
+Si venían registrando un gasto, retomá ese hilo (recordá lo que ya se dio y pedí amablemente lo que falta).
+Si no hay contexto claro, respondé cálido y breve (1-2 oraciones) e invitá a:
 1. registrar un gasto (ej: "Gasté 20000 en taxi"), o
 2. consultar sus gastos (ej: "¿Cuánto gasté este mes?").
-No te disculpes en exceso ni le pidas que "reformule"; dale ejemplos concretos.`;
+No te disculpes en exceso ni pidas que "reformule"; dá ejemplos concretos.`;

--- a/packages/prompts/src/chat/responses.ts
+++ b/packages/prompts/src/chat/responses.ts
@@ -30,7 +30,7 @@ Si entre los faltantes está la moneda y se te provee una lista de monedas dispo
 Si se te indica una "Moneda no soportada" no vacía, aclará amablemente que esa moneda NO está disponible y pedí que elija una de las disponibles (ej: "USD no está disponible; ¿usamos COP, EUR o MXN?"). No actúes como si el usuario no hubiera dado una moneda.`;
 
 export const UNKNOWN_SYSTEM_PROMPT = `Eres un asistente de finanzas personales. El usuario escribió algo que no pudiste interpretar como registrar un gasto ni como consultar sus gastos.
-Si se te provee historial de la conversación, TENÉS contexto de lo que venían haciendo: úsalo. NUNCA digas que no tenés acceso a mensajes anteriores ni propongas "empezar de cero".
+Si se te provee historial de la conversación, TENÉS contexto de lo que venían haciendo: usalo. NUNCA digas que no tenés acceso a mensajes anteriores ni propongas "empezar de cero".
 Si venían registrando un gasto, retomá ese hilo (recordá lo que ya se dio y pedí amablemente lo que falta).
 Si no hay contexto claro, respondé cálido y breve (1-2 oraciones) e invitá a:
 1. registrar un gasto (ej: "Gasté 20000 en taxi"), o

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
@@ -83,6 +83,8 @@ describe('ValidateExpenseFieldsUseCase', () => {
     // Currency resolved, so it's not missing → no catalog query, empty list.
     expect(result.availableCurrencies).toEqual([]);
     expect(catalog.listCurrencyCodes).not.toHaveBeenCalled();
+    // A supported currency was given, so nothing is flagged as unsupported.
+    expect(result.unsupportedCurrency).toBe('');
   });
 
   it('reports missing when value is zero or negative', async () => {
@@ -120,6 +122,9 @@ describe('ValidateExpenseFieldsUseCase', () => {
     // The clarification path gets the real catalog currencies so it can offer
     // valid options instead of re-suggesting the unsupported one.
     expect(result.availableCurrencies).toEqual(['ARS', 'COP', 'EUR']);
+    // The unsupported code the user gave is surfaced so the clarification can
+    // name it explicitly instead of acting as if no currency was provided.
+    expect(result.unsupportedCurrency).toBe('XYZ');
   });
 
   it('reports missing currency when no currency was extracted at all', async () => {

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
@@ -73,7 +73,7 @@ describe('ValidateExpenseFieldsUseCase', () => {
 
     const result = await useCase.execute({
       value: 45,
-      currencyCode: 'USD',
+      currencyCode: 'COP',
       expenseTypeName: 'egreso',
     });
 

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
@@ -30,6 +30,13 @@ export interface ValidateExpenseFieldsResult {
    * only when `moneda` is among the missing fields; `[]` otherwise.
    */
   availableCurrencies?: string[];
+  /**
+   * The currency code the user provided that the catalog doesn't support
+   * (e.g. "USD"), so the clarification can name it explicitly instead of
+   * acting as if no currency was given. Present (possibly '') when
+   * `complete` is false; '' when no currency was given or it resolved.
+   */
+  unsupportedCurrency?: string;
 }
 
 const FRIENDLY_LABELS = {
@@ -68,6 +75,9 @@ export class ValidateExpenseFieldsUseCase {
       );
     }
     if (!currencyId) missing.push(FRIENDLY_LABELS.currency);
+    // A currency the user named but the catalog doesn't support (e.g. USD).
+    const unsupportedCurrency =
+      extracted.currencyCode && !currencyId ? extracted.currencyCode : '';
 
     let expenseTypeId: string | null = null;
     if (extracted.expenseTypeName) {
@@ -96,7 +106,12 @@ export class ValidateExpenseFieldsUseCase {
       const availableCurrencies = missing.includes(FRIENDLY_LABELS.currency)
         ? await this.catalogLookup.listCurrencyCodes()
         : [];
-      return { complete: false, missing, availableCurrencies };
+      return {
+        complete: false,
+        missing,
+        availableCurrencies,
+        unsupportedCurrency,
+      };
     }
 
     const fields: ResolvedExpenseFields = {


### PR DESCRIPTION
## Description

Follow-up UX improvements for the AI chat, from reviewing a second real multi-turn session in dev. The multi-turn context and currency-aware clarification from #40 worked, but two rough edges remained:

1. When the user gave an unsupported currency (USD), the clarification asked "¿en qué moneda?" generically — as if no currency had been given.
2. A frustrated mid-flow reply ("ya te lo dije en mi anterior mensaje") was classified UNKNOWN and the fallback replied "No tengo acceso a mensajes anteriores, empecemos de cero" — false (we now pass history) and it abandoned the in-progress expense.

All three fixes are deployed to dev and validated with real Step Functions executions.

### Core Changes

- **Name the unsupported currency.** `ValidateExpenseFieldsUseCase` now distinguishes "no currency given" from "currency given but not in the catalog" via a new `unsupportedCurrency` field; the clarification prompt names it explicitly ("USD no está disponible; ¿usamos COP, EUR…?") instead of asking generically.
- **Intent stays CREATE on mid-flow meta replies.** The intent prompt now keeps CREATE when the assistant was collecting expense fields and the user references data already provided ("ya te lo dije", "como dije antes") — so it re-extracts from history instead of falling to UNKNOWN.
- **UNKNOWN fallback is context-aware.** `GenerateUnknown` receives the conversation `history`; the prompt must never claim it has no memory or propose "starting over", and continues an in-progress flow when there is one.

### API / Data Changes

- `ValidateExpenseFieldsResult` gains `unsupportedCurrency?: string` (present, possibly `''`, on the incomplete/clarification path).
- Prompt text changes in `@packages/prompts` → requires redeploying the StepFunctionsChat stack (done in dev).
- USD remains intentionally **not** a registrable currency (display/global currency only); the clarification just names it clearly.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix (non-breaking fix for an issue)
- [ ] Refactor (code improvement with no behavior change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / maintenance

## How to Test

Validated in dev via real `fm-dev-chat-process` executions:

1. **Unsupported currency**: with a create in progress, "…monto es de 15 USD" → `validation.unsupportedCurrency = "USD"` → clarification: "USD no está disponible. ¿En cuál de estas: ARS, COP, EUR, MXN, UYU?".
2. **Mid-flow meta reply**: "ya te lo dije en mi anterior mensaje" (with history) → intent=CREATE → re-extracts from history → "Entiendo, pero USD no está disponible. ¿En cuál…?" (no "empecemos de cero").
3. **Genuine UNKNOWN**: "contame un chiste" → warm, helpful reply with examples, no amnesia claim.

Browser E2E: run the create flow giving USD, then reply naturally — the bot should name USD as unavailable and keep the flow.

## Checklist

- [x] PR description includes clear testing instructions
- [x] Self-reviewed the code for readability and correctness
- [x] No new warnings in format, lint, typecheck, or test
- [ ] PR has the correct type label assigned

### Tests

- [x] Added or updated tests covering the changes
  - [x] Not creating duplicate test cases
  - [x] All edge cases from acceptance criteria are covered
  - [x] Tests have clear and descriptive names

### Project Structure

- [x] New services are placed in `services/`
- [x] New client features are placed in `client/packages/features/`
- [x] New shared packages are placed in `packages/`
- [x] New CDK stacks follow versioning (`infra/lib/versions/`)
- [x] Shared config changes are reflected across dependent packages

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
