### PR TITLE
feat: chat session management + preview iteration UX

### DIFF
--- a/client/packages/features/dashboard/src/domain/repositories/chat-repository.port.ts
+++ b/client/packages/features/dashboard/src/domain/repositories/chat-repository.port.ts
@@ -25,6 +25,34 @@ export interface ConfirmExpenseResult {
   messageId: string;
 }
 
+/** Lifecycle of an assistant preview that required confirmation. */
+export type ChatTaskTokenStatus =
+  | 'pending'
+  | 'confirmed'
+  | 'cancelled'
+  | 'expired'
+  | 'superseded';
+
+/** A session summary for the sidebar (newest activity first). */
+export interface ChatSessionSummary {
+  id: string;
+  startedAt: string;
+  lastMessageAt: string;
+  /** Snippet of the first user message; used as a title. */
+  preview: string | null;
+  messageCount: number;
+}
+
+/** A persisted message used to restore a conversation. */
+export interface ChatHistoryMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  taskToken: string | null;
+  taskTokenStatus: ChatTaskTokenStatus | null;
+  createdAt: string;
+}
+
 /**
  * Port consumed by the chat UI. The dashboard package implements it with
  * `ChatApiRepository` (HTTP via `ApiClient`); tests can drop in a mock.
@@ -32,4 +60,8 @@ export interface ConfirmExpenseResult {
 export interface ChatRepositoryPort {
   sendMessage(input: SendChatMessageInput): Promise<SendChatMessageAck>;
   confirmExpense(input: ConfirmExpenseInput): Promise<ConfirmExpenseResult>;
+  /** Lists the user's chat sessions for the sidebar (newest first). */
+  listSessions(): Promise<ChatSessionSummary[]>;
+  /** Returns a session's messages (oldest → newest) to restore it. */
+  getSessionMessages(sessionId: string): Promise<ChatHistoryMessage[]>;
 }

--- a/client/packages/features/dashboard/src/infrastructure/api/chat-api-repository.test.ts
+++ b/client/packages/features/dashboard/src/infrastructure/api/chat-api-repository.test.ts
@@ -1,8 +1,8 @@
 import { ChatApiRepository } from './chat-api-repository';
 import type { ApiClient } from './api-client';
 
-function makeApi(): jest.Mocked<Pick<ApiClient, 'post'>> {
-  return { post: jest.fn() };
+function makeApi(): jest.Mocked<Pick<ApiClient, 'post' | 'get'>> {
+  return { post: jest.fn(), get: jest.fn() };
 }
 
 describe('ChatApiRepository', () => {
@@ -72,6 +72,93 @@ describe('ChatApiRepository', () => {
         confirmed: true,
       });
       expect(result).toEqual({ status: 'confirmed', messageId: 'm1' });
+    });
+  });
+
+  describe('listSessions', () => {
+    it('GETs /chat/sessions and maps snake_case → camelCase', async () => {
+      const api = makeApi();
+      api.get.mockResolvedValue({
+        success: true,
+        data: {
+          sessions: [
+            {
+              id: 's1',
+              started_at: '2026-06-01T10:00:00Z',
+              last_message_at: '2026-06-12T10:00:00Z',
+              preview: 'Gasté 50',
+              message_count: 4,
+            },
+          ],
+        },
+      });
+
+      const repo = new ChatApiRepository(api as unknown as ApiClient);
+      const result = await repo.listSessions();
+
+      expect(api.get).toHaveBeenCalledWith('/chat/sessions');
+      expect(result).toEqual([
+        {
+          id: 's1',
+          startedAt: '2026-06-01T10:00:00Z',
+          lastMessageAt: '2026-06-12T10:00:00Z',
+          preview: 'Gasté 50',
+          messageCount: 4,
+        },
+      ]);
+    });
+  });
+
+  describe('getSessionMessages', () => {
+    it('GETs the session messages route and maps the rows', async () => {
+      const api = makeApi();
+      api.get.mockResolvedValue({
+        success: true,
+        data: {
+          sessionId: 's1',
+          messages: [
+            {
+              id: 'm1',
+              role: 'user',
+              content: 'Hola',
+              task_token: null,
+              task_token_status: null,
+              created_at: '2026-06-01T10:00:01Z',
+            },
+            {
+              id: 'm2',
+              role: 'assistant',
+              content: '¿Confirmás?',
+              task_token: 'tok-1',
+              task_token_status: 'pending',
+              created_at: '2026-06-01T10:00:02Z',
+            },
+          ],
+        },
+      });
+
+      const repo = new ChatApiRepository(api as unknown as ApiClient);
+      const result = await repo.getSessionMessages('s1');
+
+      expect(api.get).toHaveBeenCalledWith('/chat/sessions/s1/messages');
+      expect(result).toEqual([
+        {
+          id: 'm1',
+          role: 'user',
+          content: 'Hola',
+          taskToken: null,
+          taskTokenStatus: null,
+          createdAt: '2026-06-01T10:00:01Z',
+        },
+        {
+          id: 'm2',
+          role: 'assistant',
+          content: '¿Confirmás?',
+          taskToken: 'tok-1',
+          taskTokenStatus: 'pending',
+          createdAt: '2026-06-01T10:00:02Z',
+        },
+      ]);
     });
   });
 });

--- a/client/packages/features/dashboard/src/infrastructure/api/chat-api-repository.ts
+++ b/client/packages/features/dashboard/src/infrastructure/api/chat-api-repository.ts
@@ -1,5 +1,8 @@
 import type {
+  ChatHistoryMessage,
   ChatRepositoryPort,
+  ChatSessionSummary,
+  ChatTaskTokenStatus,
   ConfirmExpenseInput,
   ConfirmExpenseResult,
   SendChatMessageAck,
@@ -10,6 +13,25 @@ import type { ApiClient } from './api-client';
 interface ApiResponse<T> {
   success: boolean;
   data: T;
+}
+
+/** Raw session summary as returned by `GET /chat/sessions` (snake_case). */
+interface RawSessionSummary {
+  id: string;
+  started_at: string;
+  last_message_at: string;
+  preview: string | null;
+  message_count: number;
+}
+
+/** Raw message row as returned by the backend (snake_case). */
+interface RawChatMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  task_token: string | null;
+  task_token_status: ChatTaskTokenStatus | null;
+  created_at: string;
 }
 
 /**
@@ -42,5 +64,33 @@ export class ChatApiRepository implements ChatRepositoryPort {
       { taskToken: input.taskToken, confirmed: input.confirmed },
     );
     return response.data;
+  }
+
+  async listSessions(): Promise<ChatSessionSummary[]> {
+    const response =
+      await this.api.get<ApiResponse<{ sessions: RawSessionSummary[] }>>(
+        '/chat/sessions',
+      );
+    return response.data.sessions.map((s) => ({
+      id: s.id,
+      startedAt: s.started_at,
+      lastMessageAt: s.last_message_at,
+      preview: s.preview,
+      messageCount: s.message_count,
+    }));
+  }
+
+  async getSessionMessages(sessionId: string): Promise<ChatHistoryMessage[]> {
+    const response = await this.api.get<
+      ApiResponse<{ messages: RawChatMessage[] }>
+    >(`/chat/sessions/${encodeURIComponent(sessionId)}/messages`);
+    return response.data.messages.map((m) => ({
+      id: m.id,
+      role: m.role,
+      content: m.content,
+      taskToken: m.task_token,
+      taskTokenStatus: m.task_token_status,
+      createdAt: m.created_at,
+    }));
   }
 }

--- a/client/packages/features/dashboard/src/presentation/components/shared/organisms/ai-chat-drawer/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/organisms/ai-chat-drawer/index.tsx
@@ -15,9 +15,11 @@ import {
 import { useColorScheme } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useTranslation } from '@packages/i18n';
-import { isWeb } from '@packages/utils';
+import { isWeb, preferenceStorage } from '@packages/utils';
 
 import { ChatInput } from '@features/ui/components/shared/atoms/chat-input';
+import { Skeleton } from '@features/ui/components/shared/atoms/skeleton';
+import { TypingIndicator } from '@features/ui/components/shared/atoms/typing-indicator';
 import { ChatMessageList } from '@features/ui/components/shared/molecules/chat-message-list';
 import type { ChatMessage as UiChatMessage } from '@features/ui/components/shared/molecules/chat-message-list';
 import { ChatPreviewActions } from '@features/ui/components/shared/molecules/chat-preview-actions';
@@ -32,13 +34,19 @@ import {
 import {
   fontSizeScale,
   iconSize,
+  radius,
   space,
   zIndex,
 } from '@features/ui/utils/spacing';
 import { fontWeight as fontWeightTokens } from '@features/ui/utils/typography';
 
 import type { ChatEvent } from '@features/dashboard/domain/services/chat-event';
+import type {
+  ChatHistoryMessage,
+  ChatSessionSummary,
+} from '@features/dashboard/domain/repositories/chat-repository.port';
 import { AppSyncEventsClient } from '@features/dashboard/infrastructure/realtime/appsync-events-client';
+import { ChatSessionsPanel } from '@features/dashboard/presentation/components/shared/organisms/chat-sessions-panel';
 import { useChatContext } from '@features/dashboard/presentation/providers/chat-provider';
 
 export interface AIChatDrawerProps {
@@ -54,11 +62,21 @@ interface InternalMessage extends UiChatMessage {
   resolved?: boolean;
 }
 
+type DrawerView = 'chat' | 'sessions';
+
+function pad(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
 function formatTimestamp(): string {
   const now = new Date();
-  const hours = now.getHours().toString().padStart(2, '0');
-  const minutes = now.getMinutes().toString().padStart(2, '0');
-  return `${hours}:${minutes}`;
+  return `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+}
+
+function formatTimestampFromIso(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return formatTimestamp();
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
 export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
@@ -79,8 +97,22 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
     : Dimensions.get('window').width * 0.85;
   const slideAnim = useRef(new Animated.Value(drawerWidth)).current;
 
+  const buildWelcome = useCallback(
+    (): InternalMessage => ({
+      id: 'welcome',
+      message: t('aiChat.welcomeMessage'),
+      timestamp: formatTimestamp(),
+      isUser: false,
+    }),
+    [t],
+  );
+
   const [inputText, setInputText] = useState('');
   const [sessionId, setSessionId] = useState<string | undefined>(undefined);
+  const [view, setView] = useState<DrawerView>('chat');
+  const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [restoring, setRestoring] = useState(false);
   const [isWaitingForAssistant, setIsWaitingForAssistant] = useState(false);
   const [errorBanner, setErrorBanner] = useState<string | null>(null);
   const [messages, setMessages] = useState<InternalMessage[]>(() => [
@@ -91,6 +123,58 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
       isUser: false,
     },
   ]);
+
+  // ── Map persisted history → UI messages ───────────────────
+  const mapHistory = useCallback(
+    (history: ChatHistoryMessage[]): InternalMessage[] =>
+      history.map((m) => ({
+        id: m.id,
+        message: m.content,
+        timestamp: formatTimestampFromIso(m.createdAt),
+        isUser: m.role === 'user',
+        // Restore a still-pending preview so its Confirm/Cancel reappears.
+        ...(m.role !== 'user' && m.taskToken && m.taskTokenStatus === 'pending'
+          ? { taskToken: m.taskToken, pending: true }
+          : {}),
+      })),
+    [],
+  );
+
+  const loadSessionMessages = useCallback(
+    async (id: string) => {
+      setRestoring(true);
+      setErrorBanner(null);
+      try {
+        const history = await chatRepository.getSessionMessages(id);
+        setMessages(history.length ? mapHistory(history) : [buildWelcome()]);
+      } catch (err) {
+        console.warn('Failed to load session messages', err);
+        setErrorBanner(t('aiChat.error'));
+      } finally {
+        setRestoring(false);
+      }
+    },
+    [chatRepository, mapHistory, buildWelcome, t],
+  );
+
+  // ── Restore the last session when the drawer opens ────────
+  useEffect(() => {
+    if (!visible) return undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const stored = await preferenceStorage.getLastChatSession(userId);
+        if (cancelled || !stored) return;
+        setSessionId(stored);
+        await loadSessionMessages(stored);
+      } catch (err) {
+        console.warn('Failed to restore chat session', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, userId, loadSessionMessages]);
 
   // ── Animation ─────────────────────────────────────────────
   useEffect(() => {
@@ -128,19 +212,27 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
 
     const onEvent = (event: ChatEvent) => {
       setIsWaitingForAssistant(false);
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: event.messageId,
-          message: event.content,
-          timestamp: formatTimestamp(),
-          isUser: false,
-          ...(event.type === 'preview_pending' && {
-            taskToken: event.taskToken,
-            pending: true,
-          }),
-        },
-      ]);
+      setMessages((prev) => {
+        // A new preview means the user iterated on the previous one: clear
+        // older pending flags so only the latest Confirm/Cancel shows.
+        const base =
+          event.type === 'preview_pending'
+            ? prev.map((m) => (m.pending ? { ...m, pending: false } : m))
+            : prev;
+        return [
+          ...base,
+          {
+            id: event.messageId,
+            message: event.content,
+            timestamp: formatTimestamp(),
+            isUser: false,
+            ...(event.type === 'preview_pending' && {
+              taskToken: event.taskToken,
+              pending: true,
+            }),
+          },
+        ];
+      });
     };
 
     client.subscribe(onEvent).catch((err) => {
@@ -165,7 +257,11 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
       timestamp: formatTimestamp(),
       isUser: true,
     };
-    setMessages((prev) => [...prev, userMessage]);
+    // Sending iterates on any pending preview — drop stale Confirm/Cancel.
+    setMessages((prev) => [
+      ...prev.map((m) => (m.pending ? { ...m, pending: false } : m)),
+      userMessage,
+    ]);
     setInputText('');
     setIsWaitingForAssistant(true);
 
@@ -174,13 +270,51 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
         ...(sessionId !== undefined && { sessionId }),
         content: trimmed,
       });
-      if (!sessionId) setSessionId(ack.sessionId);
+      if (!sessionId) {
+        setSessionId(ack.sessionId);
+        void preferenceStorage.setLastChatSession(userId, ack.sessionId);
+      }
     } catch (err) {
       console.warn('Failed to send chat message', err);
       setErrorBanner(t('aiChat.error'));
       setIsWaitingForAssistant(false);
     }
-  }, [inputText, sessionId, chatRepository, t]);
+  }, [inputText, sessionId, chatRepository, userId, t]);
+
+  // ── Session management ────────────────────────────────────
+  const handleNewChat = useCallback(() => {
+    setSessionId(undefined);
+    setMessages([buildWelcome()]);
+    setErrorBanner(null);
+    setIsWaitingForAssistant(false);
+    setView('chat');
+    void preferenceStorage.clearLastChatSession(userId);
+  }, [buildWelcome, userId]);
+
+  const openSessions = useCallback(async () => {
+    setView('sessions');
+    setSessionsLoading(true);
+    setErrorBanner(null);
+    try {
+      setSessions(await chatRepository.listSessions());
+    } catch (err) {
+      console.warn('Failed to list sessions', err);
+      setErrorBanner(t('aiChat.error'));
+    } finally {
+      setSessionsLoading(false);
+    }
+  }, [chatRepository, t]);
+
+  const handleSelectSession = useCallback(
+    async (id: string) => {
+      setSessionId(id);
+      setView('chat');
+      setIsWaitingForAssistant(false);
+      void preferenceStorage.setLastChatSession(userId, id);
+      await loadSessionMessages(id);
+    },
+    [userId, loadSessionMessages],
+  );
 
   // ── Human-in-the-Loop confirm / cancel ────────────────────
   const handlePreviewDecision = useCallback(
@@ -219,14 +353,14 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
     ? textTokens.dark.primary
     : textTokens.light.primary;
   const closeIconColor = isDark ? neutral[400] : neutral[500];
-  const mutedColor = isDark ? textTokens.dark.muted : textTokens.light.muted;
   const errorColor = isDark
     ? textTokens.dark.primary
     : textTokens.light.primary;
 
-  // Append preview action rows immediately after their parent message.
-  // Tracks pending messages so we render the confirm/cancel buttons inline.
+  // Only the latest pending preview keeps its Confirm/Cancel actions.
   const pendingPreviews = messages.filter((m) => m.pending && m.taskToken);
+  const latestPreview = pendingPreviews[pendingPreviews.length - 1];
+  const isSessionsView = view === 'sessions';
 
   return (
     <View
@@ -282,11 +416,26 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
               gap: space.xs,
             }}
           >
-            <MaterialCommunityIcons
-              name="robot-outline"
-              size={iconSize.lg}
-              color={primary[600]}
-            />
+            {isSessionsView ? (
+              <TouchableOpacity
+                onPress={() => setView('chat')}
+                accessibilityRole="button"
+                accessibilityLabel={t('aiChat.backLabel')}
+                style={{ padding: space.s4 }}
+              >
+                <MaterialCommunityIcons
+                  name="arrow-left"
+                  size={iconSize.lg}
+                  color={primary[600]}
+                />
+              </TouchableOpacity>
+            ) : (
+              <MaterialCommunityIcons
+                name="robot-outline"
+                size={iconSize.lg}
+                color={primary[600]}
+              />
+            )}
             <Text
               style={{
                 fontSize: fontSizeScale.lg,
@@ -294,81 +443,148 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
                 color: titleColor,
               }}
             >
-              {t('aiChat.title')}
+              {isSessionsView ? t('aiChat.sessionsTitle') : t('aiChat.title')}
             </Text>
           </View>
-          <TouchableOpacity
-            onPress={handleClose}
-            accessibilityRole="button"
-            accessibilityLabel="Close"
-            style={{ padding: space.s4 }}
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: space.xs,
+            }}
           >
-            <MaterialCommunityIcons
-              name="close"
-              size={iconSize.lg}
-              color={closeIconColor}
-            />
-          </TouchableOpacity>
+            {!isSessionsView && (
+              <>
+                <TouchableOpacity
+                  onPress={handleNewChat}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('aiChat.newChatLabel')}
+                  style={{ padding: space.s4 }}
+                >
+                  <MaterialCommunityIcons
+                    name="plus"
+                    size={iconSize.lg}
+                    color={closeIconColor}
+                  />
+                </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={() => void openSessions()}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('aiChat.sessionsLabel')}
+                  style={{ padding: space.s4 }}
+                >
+                  <MaterialCommunityIcons
+                    name="history"
+                    size={iconSize.lg}
+                    color={closeIconColor}
+                  />
+                </TouchableOpacity>
+              </>
+            )}
+            <TouchableOpacity
+              onPress={handleClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+              style={{ padding: space.s4 }}
+            >
+              <MaterialCommunityIcons
+                name="close"
+                size={iconSize.lg}
+                color={closeIconColor}
+              />
+            </TouchableOpacity>
+          </View>
         </View>
 
-        {/* Messages */}
-        <View style={{ flex: 1 }}>
-          <ChatMessageList messages={messages} />
+        {isSessionsView ? (
+          <ChatSessionsPanel
+            sessions={sessions}
+            loading={sessionsLoading}
+            isDark={isDark}
+            activeSessionId={sessionId}
+            onSelect={(id) => void handleSelectSession(id)}
+            onNewChat={handleNewChat}
+            labels={{
+              newChat: t('aiChat.newChat'),
+              newChatLabel: t('aiChat.newChatLabel'),
+              noSessions: t('aiChat.noSessions'),
+              untitled: t('aiChat.untitledSession'),
+            }}
+          />
+        ) : (
+          <>
+            {/* Messages */}
+            <View style={{ flex: 1 }}>
+              {restoring ? (
+                <View style={{ padding: space.md, gap: space.sm }}>
+                  {[0, 1, 2, 3, 4].map((i) => (
+                    <Skeleton
+                      key={i}
+                      width={i % 2 === 0 ? '70%' : '55%'}
+                      height={36}
+                      borderRadius={radius.lg}
+                    />
+                  ))}
+                </View>
+              ) : (
+                <ChatMessageList messages={messages} />
+              )}
 
-          {/* HITL action rows, one per pending preview message */}
-          {pendingPreviews.map((p) => (
-            <ChatPreviewActions
-              key={`actions-${p.id}`}
-              confirmLabel={t('aiChat.confirm')}
-              cancelLabel={t('aiChat.cancel')}
-              onConfirm={() =>
-                void handlePreviewDecision(p.id, p.taskToken!, true)
-              }
-              onCancel={() =>
-                void handlePreviewDecision(p.id, p.taskToken!, false)
-              }
+              {/* HITL actions: only for the latest pending preview */}
+              {!restoring && latestPreview && (
+                <ChatPreviewActions
+                  key={`actions-${latestPreview.id}`}
+                  confirmLabel={t('aiChat.confirm')}
+                  cancelLabel={t('aiChat.cancel')}
+                  onConfirm={() =>
+                    void handlePreviewDecision(
+                      latestPreview.id,
+                      latestPreview.taskToken!,
+                      true,
+                    )
+                  }
+                  onCancel={() =>
+                    void handlePreviewDecision(
+                      latestPreview.id,
+                      latestPreview.taskToken!,
+                      false,
+                    )
+                  }
+                />
+              )}
+
+              {isWaitingForAssistant && !restoring && (
+                <TypingIndicator accessibilityLabel={t('aiChat.typingLabel')} />
+              )}
+
+              {errorBanner !== null && (
+                <Text
+                  style={{
+                    color: errorColor,
+                    fontSize: fontSizeScale.xs,
+                    marginHorizontal: space.md,
+                    marginVertical: space.xs,
+                  }}
+                >
+                  {errorBanner}
+                </Text>
+              )}
+            </View>
+
+            {/* Input — camera + mic are placeholders until Phase 2 (multimedia). */}
+            <ChatInput
+              value={inputText}
+              onChangeText={setInputText}
+              onSend={() => void handleSend()}
+              onCamera={() => undefined}
+              onMic={() => undefined}
+              placeholder={t('aiChat.placeholder')}
+              cameraLabel={t('aiChat.cameraLabel', { defaultValue: 'Camera' })}
+              micLabel={t('aiChat.micLabel', { defaultValue: 'Microphone' })}
+              sendLabel={t('aiChat.send')}
             />
-          ))}
-
-          {isWaitingForAssistant && (
-            <Text
-              style={{
-                color: mutedColor,
-                fontSize: fontSizeScale.xs,
-                marginHorizontal: space.md,
-                marginVertical: space.xs,
-              }}
-            >
-              {t('aiChat.processing')}
-            </Text>
-          )}
-
-          {errorBanner !== null && (
-            <Text
-              style={{
-                color: errorColor,
-                fontSize: fontSizeScale.xs,
-                marginHorizontal: space.md,
-                marginVertical: space.xs,
-              }}
-            >
-              {errorBanner}
-            </Text>
-          )}
-        </View>
-
-        {/* Input — camera + mic are placeholders until Phase 2 (multimedia). */}
-        <ChatInput
-          value={inputText}
-          onChangeText={setInputText}
-          onSend={() => void handleSend()}
-          onCamera={() => undefined}
-          onMic={() => undefined}
-          placeholder={t('aiChat.placeholder')}
-          cameraLabel={t('aiChat.cameraLabel', { defaultValue: 'Camera' })}
-          micLabel={t('aiChat.micLabel', { defaultValue: 'Microphone' })}
-          sendLabel={t('aiChat.send')}
-        />
+          </>
+        )}
       </Animated.View>
     </View>
   );

--- a/client/packages/features/dashboard/src/presentation/components/shared/organisms/ai-chat-drawer/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/organisms/ai-chat-drawer/index.tsx
@@ -109,6 +109,14 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
 
   const [inputText, setInputText] = useState('');
   const [sessionId, setSessionId] = useState<string | undefined>(undefined);
+  // Mirror of `sessionId` for the realtime callback: the AppSync subscription
+  // closure is created once and does NOT re-run when the session changes, so
+  // it reads the active session from this ref to filter out events that belong
+  // to other sessions still processing in the background.
+  const sessionIdRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
   const [view, setView] = useState<DrawerView>('chat');
   const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(false);
@@ -211,6 +219,13 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
     });
 
     const onEvent = (event: ChatEvent) => {
+      // The channel (`${userId}/responses`) carries events for ALL of the
+      // user's sessions. Ignore anything that isn't the active conversation
+      // so a background workflow can't leak into the wrong session (and drop
+      // events while there's no active session yet).
+      if (!sessionIdRef.current || event.sessionId !== sessionIdRef.current) {
+        return;
+      }
       setIsWaitingForAssistant(false);
       setMessages((prev) => {
         // A new preview means the user iterated on the previous one: clear
@@ -271,6 +286,10 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
         content: trimmed,
       });
       if (!sessionId) {
+        // Set the ref synchronously (before the state re-render) so the
+        // assistant's reply for this brand-new session passes the onEvent
+        // filter instead of being dropped in the gap before `sessionId` lands.
+        sessionIdRef.current = ack.sessionId;
         setSessionId(ack.sessionId);
         void preferenceStorage.setLastChatSession(userId, ack.sessionId);
       }

--- a/client/packages/features/dashboard/src/presentation/components/shared/organisms/chat-sessions-panel/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/organisms/chat-sessions-panel/index.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+import { Skeleton } from '@features/ui/components/shared/atoms/skeleton';
+import {
+  neutral,
+  primary,
+  surface,
+  textTokens,
+} from '@features/ui/utils/colors';
+import {
+  fontSizeScale,
+  iconSize,
+  radius,
+  space,
+} from '@features/ui/utils/spacing';
+import { fontWeight } from '@features/ui/utils/typography';
+
+import type { ChatSessionSummary } from '@features/dashboard/domain/repositories/chat-repository.port';
+
+export interface ChatSessionsPanelProps {
+  sessions: ChatSessionSummary[];
+  loading: boolean;
+  isDark: boolean;
+  activeSessionId?: string | undefined;
+  onSelect: (sessionId: string) => void;
+  onNewChat: () => void;
+  labels: {
+    newChat: string;
+    newChatLabel: string;
+    noSessions: string;
+    untitled: string;
+  };
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Sessions sidebar panel (ChatGPT-style): a "New chat" action on top and a
+ * tappable list of the user's past conversations, newest first.
+ */
+export function ChatSessionsPanel({
+  sessions,
+  loading,
+  isDark,
+  activeSessionId,
+  onSelect,
+  onNewChat,
+  labels,
+}: ChatSessionsPanelProps) {
+  const titleColor = isDark
+    ? textTokens.dark.primary
+    : textTokens.light.primary;
+  const mutedColor = isDark ? textTokens.dark.muted : textTokens.light.muted;
+  const itemBorder = isDark ? surface.dark.border : surface.light.border;
+  const activeBg = isDark ? surface.dark.card : neutral[100];
+
+  return (
+    <View style={{ flex: 1 }}>
+      <TouchableOpacity
+        onPress={onNewChat}
+        accessibilityRole="button"
+        accessibilityLabel={labels.newChatLabel}
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: space.xs,
+          margin: space.md,
+          paddingVertical: space.sm,
+          paddingHorizontal: space.md,
+          borderRadius: radius.lg,
+          backgroundColor: primary[600],
+        }}
+      >
+        <MaterialCommunityIcons
+          name="plus"
+          size={iconSize.md}
+          color={surface.light.background}
+        />
+        <Text
+          style={{
+            color: surface.light.background,
+            fontSize: fontSizeScale.sm,
+            fontWeight: fontWeight.semibold,
+          }}
+        >
+          {labels.newChat}
+        </Text>
+      </TouchableOpacity>
+
+      {loading ? (
+        <View style={{ paddingHorizontal: space.md, gap: space.sm }}>
+          {[0, 1, 2, 3].map((i) => (
+            <Skeleton key={i} height={48} borderRadius={radius.md} />
+          ))}
+        </View>
+      ) : sessions.length === 0 ? (
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: space.lg,
+          }}
+        >
+          <Text
+            style={{ color: mutedColor, fontSize: fontSizeScale.sm }}
+            accessibilityRole="text"
+          >
+            {labels.noSessions}
+          </Text>
+        </View>
+      ) : (
+        <ScrollView style={{ flex: 1 }}>
+          {sessions.map((session) => {
+            const isActive = session.id === activeSessionId;
+            return (
+              <TouchableOpacity
+                key={session.id}
+                onPress={() => onSelect(session.id)}
+                accessibilityRole="button"
+                style={{
+                  paddingVertical: space.sm,
+                  paddingHorizontal: space.md,
+                  marginHorizontal: space.sm,
+                  borderRadius: radius.md,
+                  borderBottomWidth: 1,
+                  borderBottomColor: itemBorder,
+                  ...(isActive && { backgroundColor: activeBg }),
+                }}
+              >
+                <Text
+                  numberOfLines={1}
+                  style={{
+                    color: titleColor,
+                    fontSize: fontSizeScale.sm,
+                    fontWeight: fontWeight.medium,
+                  }}
+                >
+                  {session.preview ?? labels.untitled}
+                </Text>
+                <Text
+                  style={{
+                    color: mutedColor,
+                    fontSize: fontSizeScale['2xs'],
+                    marginTop: space.s4,
+                  }}
+                >
+                  {formatDate(session.lastMessageAt)}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      )}
+    </View>
+  );
+}

--- a/client/packages/features/ui/src/components/index.ts
+++ b/client/packages/features/ui/src/components/index.ts
@@ -67,3 +67,5 @@ export { ChatInput } from './shared/atoms/chat-input';
 export type { ChatInputProps } from './shared/atoms/chat-input';
 export { ChatMessageList } from './shared/molecules/chat-message-list';
 export type { ChatMessageListProps } from './shared/molecules/chat-message-list';
+export { TypingIndicator } from './shared/atoms/typing-indicator';
+export type { TypingIndicatorProps } from './shared/atoms/typing-indicator';

--- a/client/packages/features/ui/src/components/shared/atoms/typing-indicator/index.test.tsx
+++ b/client/packages/features/ui/src/components/shared/atoms/typing-indicator/index.test.tsx
@@ -1,0 +1,11 @@
+import { TypingIndicator } from '.';
+
+describe('TypingIndicator', () => {
+  it('exports a function component', () => {
+    expect(typeof TypingIndicator).toBe('function');
+  });
+
+  it('has the expected name', () => {
+    expect(TypingIndicator.name).toBe('TypingIndicator');
+  });
+});

--- a/client/packages/features/ui/src/components/shared/atoms/typing-indicator/index.tsx
+++ b/client/packages/features/ui/src/components/shared/atoms/typing-indicator/index.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Animated, View, useColorScheme } from 'react-native';
+
+import { neutral } from '@features/ui/utils/colors';
+import { radius, space } from '@features/ui/utils/spacing';
+
+export interface TypingIndicatorProps {
+  /** Accessibility label announced by screen readers (e.g. "Assistant is typing"). */
+  accessibilityLabel: string;
+}
+
+const DOT_COUNT = 3;
+const DURATION = 400;
+
+/**
+ * Animated "assistant is typing" indicator. Renders three pulsing dots
+ * inside an assistant-style bubble so it reads as the bot composing a reply,
+ * replacing a plain "Processing…" label.
+ */
+export function TypingIndicator({ accessibilityLabel }: TypingIndicatorProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const bubbleBackground = isDark ? neutral[700] : neutral[200];
+  const dotColor = isDark ? neutral[400] : neutral[500];
+
+  // One Animated.Value per dot, staggered so the pulse travels left → right.
+  const dots = useMemo(
+    () => Array.from({ length: DOT_COUNT }, () => new Animated.Value(0.3)),
+    [],
+  );
+  const animationsRef = useRef<Animated.CompositeAnimation | null>(null);
+
+  useEffect(() => {
+    const loops = dots.map((dot, index) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(index * (DURATION / 2)),
+          Animated.timing(dot, {
+            toValue: 1,
+            duration: DURATION,
+            useNativeDriver: true,
+          }),
+          Animated.timing(dot, {
+            toValue: 0.3,
+            duration: DURATION,
+            useNativeDriver: true,
+          }),
+        ]),
+      ),
+    );
+    const animation = Animated.parallel(loops);
+    animationsRef.current = animation;
+    animation.start();
+
+    return () => {
+      animation.stop();
+    };
+  }, [dots]);
+
+  return (
+    <View
+      accessibilityRole="text"
+      accessibilityLabel={accessibilityLabel}
+      style={{
+        alignSelf: 'flex-start',
+        marginBottom: space.xs,
+        marginHorizontal: space.md,
+      }}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: space.s4,
+          backgroundColor: bubbleBackground,
+          borderRadius: radius.lg,
+          paddingHorizontal: space.sm,
+          paddingVertical: space.sm,
+        }}
+      >
+        {dots.map((dot, index) => (
+          <Animated.View
+            key={index}
+            style={{
+              width: space.xs,
+              height: space.xs,
+              borderRadius: radius.sm,
+              backgroundColor: dotColor,
+              opacity: dot,
+            }}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/client/packages/i18n/src/locales/en/dashboard/index.ts
+++ b/client/packages/i18n/src/locales/en/dashboard/index.ts
@@ -116,9 +116,18 @@ export const dashboard = {
       "Got it! This feature is under development. Soon I'll be able to create expenses from your messages automatically.",
     send: 'Send',
     processing: 'Processing...',
+    typingLabel: 'Assistant is typing',
     error: 'Something went wrong. Please try again.',
     confirm: 'Confirm',
     cancel: 'Cancel',
+    newChat: 'New chat',
+    newChatLabel: 'Start a new chat',
+    sessionsTitle: 'Chats',
+    sessionsLabel: 'View chats',
+    backLabel: 'Back',
+    noSessions: 'No conversations yet',
+    untitledSession: 'Conversation',
+    loadingSessions: 'Loading conversations...',
   },
 } as const;
 

--- a/client/packages/i18n/src/locales/es/dashboard/index.ts
+++ b/client/packages/i18n/src/locales/es/dashboard/index.ts
@@ -116,9 +116,18 @@ export const dashboard = {
       '¡Entendido! Esta funcionalidad está en desarrollo. Pronto podré crear gastos desde tus mensajes automáticamente.',
     send: 'Enviar',
     processing: 'Procesando...',
+    typingLabel: 'El asistente está escribiendo',
     error: 'Hubo un problema. Inténtalo de nuevo.',
     confirm: 'Confirmar',
     cancel: 'Cancelar',
+    newChat: 'Nuevo chat',
+    newChatLabel: 'Iniciar un nuevo chat',
+    sessionsTitle: 'Conversaciones',
+    sessionsLabel: 'Ver conversaciones',
+    backLabel: 'Volver',
+    noSessions: 'Aún no tienes conversaciones',
+    untitledSession: 'Conversación',
+    loadingSessions: 'Cargando conversaciones...',
   },
 } as const;
 

--- a/client/packages/utils/src/preference-storage.test.ts
+++ b/client/packages/utils/src/preference-storage.test.ts
@@ -3,6 +3,7 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   default: {
     getItem: jest.fn().mockResolvedValue(null),
     setItem: jest.fn().mockResolvedValue(undefined),
+    removeItem: jest.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -11,6 +12,7 @@ import { preferenceStorage } from './preference-storage';
 
 const mockGetItem = AsyncStorage.getItem as jest.Mock;
 const mockSetItem = AsyncStorage.setItem as jest.Mock;
+const mockRemoveItem = AsyncStorage.removeItem as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -57,5 +59,27 @@ describe('preferenceStorage.setLanguage', () => {
   it('calls AsyncStorage.setItem with the language key and value', async () => {
     await preferenceStorage.setLanguage('es');
     expect(mockSetItem).toHaveBeenCalledWith('pref:language', 'es');
+  });
+});
+
+describe('preferenceStorage chat session', () => {
+  it('reads the per-user last chat session key', async () => {
+    mockGetItem.mockResolvedValue('session-1');
+    const result = await preferenceStorage.getLastChatSession('user-1');
+    expect(mockGetItem).toHaveBeenCalledWith('chat:lastSession:user-1');
+    expect(result).toBe('session-1');
+  });
+
+  it('writes the per-user last chat session key', async () => {
+    await preferenceStorage.setLastChatSession('user-1', 'session-2');
+    expect(mockSetItem).toHaveBeenCalledWith(
+      'chat:lastSession:user-1',
+      'session-2',
+    );
+  });
+
+  it('clears the per-user last chat session key', async () => {
+    await preferenceStorage.clearLastChatSession('user-1');
+    expect(mockRemoveItem).toHaveBeenCalledWith('chat:lastSession:user-1');
   });
 });

--- a/client/packages/utils/src/preference-storage.ts
+++ b/client/packages/utils/src/preference-storage.ts
@@ -5,9 +5,18 @@ const KEYS = {
   LANGUAGE: 'pref:language',
 } as const;
 
+/** Per-user key for the last active chat session (restored on reload). */
+const lastChatSessionKey = (userId: string) => `chat:lastSession:${userId}`;
+
 export const preferenceStorage = {
   getTheme: () => AsyncStorage.getItem(KEYS.THEME),
   setTheme: (v: string) => AsyncStorage.setItem(KEYS.THEME, v),
   getLanguage: () => AsyncStorage.getItem(KEYS.LANGUAGE),
   setLanguage: (v: string) => AsyncStorage.setItem(KEYS.LANGUAGE, v),
+  getLastChatSession: (userId: string) =>
+    AsyncStorage.getItem(lastChatSessionKey(userId)),
+  setLastChatSession: (userId: string, sessionId: string) =>
+    AsyncStorage.setItem(lastChatSessionKey(userId), sessionId),
+  clearLastChatSession: (userId: string) =>
+    AsyncStorage.removeItem(lastChatSessionKey(userId)),
 };

--- a/infra/lib/versions/v2/lambda-chat-stack.test.ts
+++ b/infra/lib/versions/v2/lambda-chat-stack.test.ts
@@ -17,11 +17,26 @@ jest.mock('./api-gateway-stack', () => ({
 
 const mockChatAddMethod = jest.fn();
 const mockConfirmAddMethod = jest.fn();
+const mockSessionsAddMethod = jest.fn();
+const mockSessionMessagesAddMethod = jest.fn();
 
 const mockConfirmResource = { addMethod: mockConfirmAddMethod };
+const mockSessionMessagesResource = { addMethod: mockSessionMessagesAddMethod };
+const mockSessionIdResource = {
+  addResource: jest.fn().mockReturnValue(mockSessionMessagesResource),
+};
+const mockSessionsResource = {
+  addMethod: mockSessionsAddMethod,
+  addResource: jest.fn().mockReturnValue(mockSessionIdResource),
+};
+
+function chatAddResource(name: string) {
+  return name === 'sessions' ? mockSessionsResource : mockConfirmResource;
+}
+
 const mockChatResource = {
   addMethod: mockChatAddMethod,
-  addResource: jest.fn().mockReturnValue(mockConfirmResource),
+  addResource: jest.fn().mockImplementation(chatAddResource),
 };
 
 const mockModel = { modelId: 'mock-model' };
@@ -29,6 +44,7 @@ const mockAuthWithBody = {
   authorizationType: 'COGNITO',
   requestModels: { 'application/json': mockModel },
 };
+const mockAuthOnly = { authorizationType: 'COGNITO' };
 
 const mockGateway = {
   api: {
@@ -36,6 +52,7 @@ const mockGateway = {
   },
   createModel: jest.fn().mockReturnValue(mockModel),
   authWithBody: jest.fn().mockReturnValue(mockAuthWithBody),
+  authOnly: jest.fn().mockReturnValue(mockAuthOnly),
 };
 
 const mockDeps = { getStack: jest.fn().mockReturnValue(mockGateway) };
@@ -114,10 +131,15 @@ function createStack(overrides: Partial<typeof defaultProps> = {}) {
 describe('LambdaChatStack', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockChatResource.addResource.mockReturnValue(mockConfirmResource);
+    mockChatResource.addResource.mockImplementation(chatAddResource);
+    mockSessionsResource.addResource.mockReturnValue(mockSessionIdResource);
+    mockSessionIdResource.addResource.mockReturnValue(
+      mockSessionMessagesResource,
+    );
     mockGateway.api.root.addResource.mockReturnValue(mockChatResource);
     mockGateway.createModel.mockReturnValue(mockModel);
     mockGateway.authWithBody.mockReturnValue(mockAuthWithBody);
+    mockGateway.authOnly.mockReturnValue(mockAuthOnly);
     mockDeps.getStack.mockReturnValue(mockGateway);
   });
 
@@ -252,7 +274,7 @@ describe('LambdaChatStack', () => {
       expect(methods).toContain('POST');
     });
 
-    test('does not add GET/PUT/PATCH/DELETE methods', () => {
+    test('does not add GET/PUT/PATCH/DELETE methods on /chat or /chat/confirm', () => {
       createStack();
       const allMethods = [
         ...mockChatAddMethod.mock.calls.map((c: unknown[]) => c[0]),
@@ -263,7 +285,43 @@ describe('LambdaChatStack', () => {
       );
     });
 
-    test('both routes use Cognito authorization', () => {
+    test('creates /chat/sessions sub-resource', () => {
+      createStack();
+      expect(mockChatResource.addResource).toHaveBeenCalledWith('sessions');
+    });
+
+    test('creates /chat/sessions/{id}/messages nested resources', () => {
+      createStack();
+      expect(mockSessionsResource.addResource).toHaveBeenCalledWith('{id}');
+      expect(mockSessionIdResource.addResource).toHaveBeenCalledWith(
+        'messages',
+      );
+    });
+
+    test('adds GET on /chat/sessions and /chat/sessions/{id}/messages', () => {
+      createStack();
+      expect(
+        mockSessionsAddMethod.mock.calls.map((c: unknown[]) => c[0]),
+      ).toContain('GET');
+      expect(
+        mockSessionMessagesAddMethod.mock.calls.map((c: unknown[]) => c[0]),
+      ).toContain('GET');
+    });
+
+    test('session routes use Cognito authorization via authOnly', () => {
+      createStack();
+      expect(mockGateway.authOnly).toHaveBeenCalled();
+      const allCalls = [
+        ...(mockSessionsAddMethod.mock.calls as unknown[][]),
+        ...(mockSessionMessagesAddMethod.mock.calls as unknown[][]),
+      ];
+      for (const call of allCalls) {
+        const opts = call[2] as Record<string, unknown>;
+        expect(opts.authorizationType).toBe('COGNITO');
+      }
+    });
+
+    test('both POST routes use Cognito authorization', () => {
       createStack();
       const allCalls = [
         ...(mockChatAddMethod.mock.calls as unknown[][]),

--- a/infra/lib/versions/v2/lambda-chat-stack.ts
+++ b/infra/lib/versions/v2/lambda-chat-stack.ts
@@ -132,6 +132,16 @@ export class LambdaChatStack extends BaseStack {
       gateway.authWithBody(passthroughModel),
     );
 
+    // GET /chat/sessions — list the user's sessions for the sidebar.
+    const sessionsResource = chatResource.addResource('sessions');
+    sessionsResource.addMethod('GET', integration, gateway.authOnly());
+
+    // GET /chat/sessions/{id}/messages — restore a session's conversation.
+    const sessionMessagesResource = sessionsResource
+      .addResource('{id}')
+      .addResource('messages');
+    sessionMessagesResource.addMethod('GET', integration, gateway.authOnly());
+
     // ── Cross-version export ────────────────────────────────
     exportForCrossVersion(
       this,

--- a/infra/lib/versions/v2/step-functions-chat-stack.test.ts
+++ b/infra/lib/versions/v2/step-functions-chat-stack.test.ts
@@ -102,6 +102,7 @@ jest.mock('aws-cdk-lib/aws-stepfunctions', () => ({
   DefinitionBody: { fromChainable: jest.fn().mockReturnValue('def-body') },
   LogLevel: { ALL: 'ALL' },
   Pass: jest.fn().mockImplementation(() => new MockChain()),
+  Succeed: jest.fn().mockImplementation(() => new MockChain()),
   Choice: jest.fn().mockImplementation(() => {
     const choiceObj = {
       when: jest.fn().mockReturnThis(),
@@ -114,6 +115,8 @@ jest.mock('aws-cdk-lib/aws-stepfunctions', () => ({
     stringEquals: jest.fn(),
     stringMatches: jest.fn(),
     booleanEquals: jest.fn(),
+    isPresent: jest.fn(),
+    and: jest.fn(),
   },
   JsonPath: { taskToken: 'TASK_TOKEN_PLACEHOLDER' },
   TaskInput: {

--- a/infra/lib/versions/v2/step-functions-chat-stack.ts
+++ b/infra/lib/versions/v2/step-functions-chat-stack.ts
@@ -23,6 +23,7 @@ import {
   LogLevel,
   StateMachine,
   StateMachineType,
+  Succeed,
   TaskInput,
 } from 'aws-cdk-lib/aws-stepfunctions';
 import {
@@ -408,7 +409,20 @@ export class StepFunctionsChatStack extends BaseStack {
     );
 
     // ── Choice states ───────────────────────────────────────
+    // When the user iterates on a preview, the send-message use case releases
+    // this paused execution with `{ confirmed: false, superseded: true }`.
+    // End silently: don't create an expense and don't publish a cancellation
+    // (a new preview is already on its way from the iterating message).
+    const supersededSucceed = new Succeed(this, 'PreviewSuperseded');
+
     const confirmedChoice = new Choice(this, 'Confirmed?')
+      .when(
+        Condition.and(
+          Condition.isPresent('$.confirmation.superseded'),
+          Condition.booleanEquals('$.confirmation.superseded', true),
+        ),
+        supersededSucceed,
+      )
       .when(
         Condition.booleanEquals('$.confirmation.confirmed', true),
         createExpense.next(generateConfirmation).next(saveCreatedExpense),

--- a/packages/migrations/src/migrations/4/1/0/1_down_add_superseded_status.sql
+++ b/packages/migrations/src/migrations/4/1/0/1_down_add_superseded_status.sql
@@ -1,0 +1,16 @@
+-- Revert the 'superseded' status. Normalize existing rows to 'cancelled'
+-- first so the tightened CHECK constraint can be re-applied.
+
+UPDATE financial_management.chat_messages
+  SET task_token_status = 'cancelled'
+  WHERE task_token_status = 'superseded';
+
+ALTER TABLE financial_management.chat_messages
+  DROP CONSTRAINT chk_chat_messages_task_token_status;
+
+ALTER TABLE financial_management.chat_messages
+  ADD CONSTRAINT chk_chat_messages_task_token_status
+  CHECK (
+    task_token_status IS NULL
+    OR task_token_status IN ('pending', 'confirmed', 'cancelled', 'expired')
+  );

--- a/packages/migrations/src/migrations/4/1/0/1_up_add_superseded_status.sql
+++ b/packages/migrations/src/migrations/4/1/0/1_up_add_superseded_status.sql
@@ -1,0 +1,15 @@
+-- Allow 'superseded' as a chat_messages.task_token_status.
+-- When the user iterates on an expense preview (sends a new message while a
+-- preview is still pending), the previous preview's paused Step Functions
+-- execution is released and its message is marked 'superseded' so the client
+-- shows only the latest preview and no stale execution times out.
+
+ALTER TABLE financial_management.chat_messages
+  DROP CONSTRAINT chk_chat_messages_task_token_status;
+
+ALTER TABLE financial_management.chat_messages
+  ADD CONSTRAINT chk_chat_messages_task_token_status
+  CHECK (
+    task_token_status IS NULL
+    OR task_token_status IN ('pending', 'confirmed', 'cancelled', 'expired', 'superseded')
+  );

--- a/packages/migrations/src/migrations/4/1/0/version.test.ts
+++ b/packages/migrations/src/migrations/4/1/0/version.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import versionConfig from './version';
+
+const migrationDir = __dirname;
+
+describe('migration v4.1.0', () => {
+  it('has a description', () => {
+    expect(versionConfig.description).toBeTruthy();
+    expect(typeof versionConfig.description).toBe('string');
+  });
+
+  it('declares one script', () => {
+    expect(versionConfig.scripts).toHaveLength(1);
+  });
+
+  it('all sql scripts reference existing files', () => {
+    for (const script of versionConfig.scripts) {
+      if (script.type === 'sql' || script.type === 'seed') {
+        const upFile = path.join(migrationDir, `${script.up}.sql`);
+        const downFile = path.join(migrationDir, `${script.down}.sql`);
+        expect(fs.existsSync(upFile)).toBe(true);
+        expect(fs.existsSync(downFile)).toBe(true);
+      }
+    }
+  });
+
+  it('up adds the superseded value to the status CHECK', () => {
+    const script = versionConfig.scripts[0]!;
+    if (script.type !== 'sql') return;
+    const sql = fs.readFileSync(
+      path.join(migrationDir, `${script.up}.sql`),
+      'utf-8',
+    );
+    expect(sql).toContain('chk_chat_messages_task_token_status');
+    expect(sql).toContain('superseded');
+  });
+
+  it('down normalizes superseded rows before tightening the constraint', () => {
+    const script = versionConfig.scripts[0]!;
+    if (script.type !== 'sql') return;
+    const sql = fs.readFileSync(
+      path.join(migrationDir, `${script.down}.sql`),
+      'utf-8',
+    );
+    expect(sql).toContain("SET task_token_status = 'cancelled'");
+    expect(sql).not.toContain("'superseded')");
+  });
+});

--- a/packages/migrations/src/migrations/4/1/0/version.ts
+++ b/packages/migrations/src/migrations/4/1/0/version.ts
@@ -1,0 +1,9 @@
+import { config, sqlScript } from 'src/lib/version-config';
+
+export default config({
+  description:
+    "Allow 'superseded' as a chat_messages.task_token_status so iterated expense previews supersede the previous one",
+  scripts: [
+    sqlScript('1_up_add_superseded_status', '1_down_add_superseded_status'),
+  ],
+});

--- a/services/chat/src/application/use-cases/confirm-pending-expense.use-case.test.ts
+++ b/services/chat/src/application/use-cases/confirm-pending-expense.use-case.test.ts
@@ -8,6 +8,7 @@ function makeMockMessageRepo(): jest.Mocked<ChatMessageRepository> {
     create: jest.fn(),
     findRecentBySession: jest.fn(),
     findPendingByTaskToken: jest.fn(),
+    findPendingPreviewsBySession: jest.fn().mockResolvedValue([]),
     updateTaskTokenStatus: jest.fn(),
   };
 }

--- a/services/chat/src/application/use-cases/get-session-messages.use-case.test.ts
+++ b/services/chat/src/application/use-cases/get-session-messages.use-case.test.ts
@@ -1,0 +1,93 @@
+import { GetSessionMessagesUseCase } from './get-session-messages.use-case';
+import type { ChatMessage } from '@services/chat/domain/entities/chat-message';
+import type { ChatSession } from '@services/chat/domain/entities/chat-session';
+import type { ChatMessageRepository } from '@services/chat/domain/repositories/chat-message.repository';
+import type { ChatSessionRepository } from '@services/chat/domain/repositories/chat-session.repository';
+import { UnauthorizedError } from '@packages/models/shared/utils/errors';
+
+function makeMockSessionRepo(): jest.Mocked<ChatSessionRepository> {
+  return {
+    findByIdAndUserUid: jest.fn(),
+    create: jest.fn(),
+    touchLastMessage: jest.fn(),
+    findByUser: jest.fn(),
+  };
+}
+
+function makeMockMessageRepo(): jest.Mocked<ChatMessageRepository> {
+  return {
+    create: jest.fn(),
+    findRecentBySession: jest.fn().mockResolvedValue([]),
+    findPendingByTaskToken: jest.fn(),
+    findPendingPreviewsBySession: jest.fn().mockResolvedValue([]),
+    updateTaskTokenStatus: jest.fn(),
+  };
+}
+
+const UID = 'uid-1';
+
+const mockSession: ChatSession = {
+  id: 'session-1',
+  user_id: 'user-id-1',
+  started_at: '2026-06-06T10:00:00Z',
+  last_message_at: '2026-06-06T10:00:00Z',
+  metadata: {},
+  created_at: '2026-06-06T10:00:00Z',
+  updated_at: '2026-06-06T10:00:00Z',
+  created_by: 'u@test.com',
+  modified_by: 'u@test.com',
+};
+
+const mockMessages: ChatMessage[] = [
+  {
+    id: 'msg-1',
+    session_id: 'session-1',
+    role: 'user',
+    content: 'Hola',
+    attachment_s3_key: null,
+    attachment_type: null,
+    expense_id: null,
+    task_token: null,
+    task_token_status: null,
+    created_at: '2026-06-06T10:00:01Z',
+    updated_at: '2026-06-06T10:00:01Z',
+    created_by: 'u@test.com',
+    modified_by: 'u@test.com',
+  },
+];
+
+describe('GetSessionMessagesUseCase', () => {
+  it('returns the session messages when the session belongs to the user', async () => {
+    const sessionRepo = makeMockSessionRepo();
+    const messageRepo = makeMockMessageRepo();
+    sessionRepo.findByIdAndUserUid.mockResolvedValue(mockSession);
+    messageRepo.findRecentBySession.mockResolvedValue(mockMessages);
+
+    const useCase = new GetSessionMessagesUseCase(sessionRepo, messageRepo);
+    const result = await useCase.execute('session-1', UID);
+
+    expect(result).toBe(mockMessages);
+    expect(sessionRepo.findByIdAndUserUid).toHaveBeenCalledWith(
+      'session-1',
+      UID,
+    );
+    expect(messageRepo.findRecentBySession).toHaveBeenCalledWith(
+      'session-1',
+      UID,
+      expect.any(Number),
+    );
+  });
+
+  it('throws UnauthorizedError when the session does not belong to the user', async () => {
+    const sessionRepo = makeMockSessionRepo();
+    const messageRepo = makeMockMessageRepo();
+    sessionRepo.findByIdAndUserUid.mockResolvedValue(null);
+
+    const useCase = new GetSessionMessagesUseCase(sessionRepo, messageRepo);
+
+    await expect(useCase.execute('stranger-session', UID)).rejects.toThrow(
+      UnauthorizedError,
+    );
+    expect(messageRepo.findRecentBySession).not.toHaveBeenCalled();
+  });
+});

--- a/services/chat/src/application/use-cases/get-session-messages.use-case.ts
+++ b/services/chat/src/application/use-cases/get-session-messages.use-case.ts
@@ -1,0 +1,37 @@
+import type { ChatMessage } from '@services/chat/domain/entities/chat-message';
+import type { ChatMessageRepository } from '@services/chat/domain/repositories/chat-message.repository';
+import type { ChatSessionRepository } from '@services/chat/domain/repositories/chat-session.repository';
+import { UnauthorizedError } from '@packages/models/shared/utils/errors';
+
+/** How many recent messages to return when restoring a session. */
+const RESTORE_LIMIT = 200;
+
+/**
+ * Returns the messages of a session (oldest → newest) so the client can
+ * restore the conversation on reload or when switching sessions.
+ *
+ * Ownership is verified first: a session that doesn't belong to the user
+ * throws `UnauthorizedError` instead of leaking an empty conversation.
+ */
+export class GetSessionMessagesUseCase {
+  constructor(
+    private readonly sessionRepository: ChatSessionRepository,
+    private readonly messageRepository: ChatMessageRepository,
+  ) {}
+
+  async execute(sessionId: string, uid: string): Promise<ChatMessage[]> {
+    const session = await this.sessionRepository.findByIdAndUserUid(
+      sessionId,
+      uid,
+    );
+    if (!session) {
+      throw new UnauthorizedError();
+    }
+
+    return this.messageRepository.findRecentBySession(
+      sessionId,
+      uid,
+      RESTORE_LIMIT,
+    );
+  }
+}

--- a/services/chat/src/application/use-cases/list-sessions.use-case.test.ts
+++ b/services/chat/src/application/use-cases/list-sessions.use-case.test.ts
@@ -1,0 +1,54 @@
+import { ListSessionsUseCase } from './list-sessions.use-case';
+import type { ChatSessionRepository } from '@services/chat/domain/repositories/chat-session.repository';
+import type { ChatSessionSummary } from '@services/chat/domain/entities/chat-session';
+
+function makeMockSessionRepo(): jest.Mocked<ChatSessionRepository> {
+  return {
+    findByIdAndUserUid: jest.fn(),
+    create: jest.fn(),
+    touchLastMessage: jest.fn(),
+    findByUser: jest.fn(),
+  };
+}
+
+const UID = 'uid-1';
+
+const summaries: ChatSessionSummary[] = [
+  {
+    id: 'session-2',
+    started_at: '2026-06-10T10:00:00Z',
+    last_message_at: '2026-06-12T10:00:00Z',
+    preview: 'Gasté 50 en el super',
+    message_count: 4,
+  },
+  {
+    id: 'session-1',
+    started_at: '2026-06-01T10:00:00Z',
+    last_message_at: '2026-06-05T10:00:00Z',
+    preview: '¿Cuánto gasté este mes?',
+    message_count: 2,
+  },
+];
+
+describe('ListSessionsUseCase', () => {
+  it('returns the user sessions from the repository', async () => {
+    const repo = makeMockSessionRepo();
+    repo.findByUser.mockResolvedValue(summaries);
+    const useCase = new ListSessionsUseCase(repo);
+
+    const result = await useCase.execute(UID);
+
+    expect(result).toBe(summaries);
+    expect(repo.findByUser).toHaveBeenCalledWith(UID, expect.any(Number));
+  });
+
+  it('forwards an explicit limit', async () => {
+    const repo = makeMockSessionRepo();
+    repo.findByUser.mockResolvedValue([]);
+    const useCase = new ListSessionsUseCase(repo);
+
+    await useCase.execute(UID, 10);
+
+    expect(repo.findByUser).toHaveBeenCalledWith(UID, 10);
+  });
+});

--- a/services/chat/src/application/use-cases/list-sessions.use-case.ts
+++ b/services/chat/src/application/use-cases/list-sessions.use-case.ts
@@ -1,0 +1,20 @@
+import type { ChatSessionSummary } from '@services/chat/domain/entities/chat-session';
+import type { ChatSessionRepository } from '@services/chat/domain/repositories/chat-session.repository';
+
+/** Cap the sidebar to a sane number of recent sessions. */
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Lists the authenticated user's chat sessions for the sidebar
+ * (newest activity first), so the client can switch between them.
+ */
+export class ListSessionsUseCase {
+  constructor(private readonly sessionRepository: ChatSessionRepository) {}
+
+  async execute(
+    uid: string,
+    limit: number = DEFAULT_LIMIT,
+  ): Promise<ChatSessionSummary[]> {
+    return this.sessionRepository.findByUser(uid, limit);
+  }
+}

--- a/services/chat/src/application/use-cases/save-assistant-message.use-case.test.ts
+++ b/services/chat/src/application/use-cases/save-assistant-message.use-case.test.ts
@@ -9,6 +9,7 @@ function makeMessageRepo(): jest.Mocked<ChatMessageRepository> {
     create: jest.fn(),
     findRecentBySession: jest.fn(),
     findPendingByTaskToken: jest.fn(),
+    findPendingPreviewsBySession: jest.fn().mockResolvedValue([]),
     updateTaskTokenStatus: jest.fn(),
   };
 }
@@ -18,6 +19,7 @@ function makeSessionRepo(): jest.Mocked<ChatSessionRepository> {
     findByIdAndUserUid: jest.fn(),
     create: jest.fn(),
     touchLastMessage: jest.fn(),
+    findByUser: jest.fn(),
   };
 }
 

--- a/services/chat/src/application/use-cases/send-message.use-case.test.ts
+++ b/services/chat/src/application/use-cases/send-message.use-case.test.ts
@@ -4,12 +4,14 @@ import type { ChatSession } from '@services/chat/domain/entities/chat-session';
 import type { ChatMessageRepository } from '@services/chat/domain/repositories/chat-message.repository';
 import type { ChatSessionRepository } from '@services/chat/domain/repositories/chat-session.repository';
 import type { WorkflowStarterService } from '@services/chat/domain/services/workflow-starter.service';
+import type { WorkflowCallbackService } from '@services/chat/domain/services/workflow-callback.service';
 
 function makeMockSessionRepo(): jest.Mocked<ChatSessionRepository> {
   return {
     findByIdAndUserUid: jest.fn(),
     create: jest.fn(),
     touchLastMessage: jest.fn(),
+    findByUser: jest.fn(),
   };
 }
 
@@ -18,6 +20,7 @@ function makeMockMessageRepo(): jest.Mocked<ChatMessageRepository> {
     create: jest.fn(),
     findRecentBySession: jest.fn().mockResolvedValue([]),
     findPendingByTaskToken: jest.fn(),
+    findPendingPreviewsBySession: jest.fn().mockResolvedValue([]),
     updateTaskTokenStatus: jest.fn(),
   };
 }
@@ -25,6 +28,12 @@ function makeMockMessageRepo(): jest.Mocked<ChatMessageRepository> {
 function makeMockStarter(): jest.Mocked<WorkflowStarterService> {
   return {
     start: jest.fn(),
+  };
+}
+
+function makeMockCallback(): jest.Mocked<WorkflowCallbackService> {
+  return {
+    resume: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -74,7 +83,12 @@ describe('SendMessageUseCase', () => {
       messageRepo.create.mockResolvedValue(mockUserMessage);
       starter.start.mockResolvedValue(mockExecution);
 
-      const useCase = new SendMessageUseCase(sessionRepo, messageRepo, starter);
+      const useCase = new SendMessageUseCase(
+        sessionRepo,
+        messageRepo,
+        starter,
+        makeMockCallback(),
+      );
       const result = await useCase.execute(
         { content: 'Gasté $45 en la cena' },
         UID,
@@ -104,7 +118,12 @@ describe('SendMessageUseCase', () => {
       messageRepo.create.mockResolvedValue(mockUserMessage);
       starter.start.mockResolvedValue(mockExecution);
 
-      const useCase = new SendMessageUseCase(sessionRepo, messageRepo, starter);
+      const useCase = new SendMessageUseCase(
+        sessionRepo,
+        messageRepo,
+        starter,
+        makeMockCallback(),
+      );
       await useCase.execute(
         { sessionId: 'session-1', content: 'Another message' },
         UID,
@@ -124,7 +143,12 @@ describe('SendMessageUseCase', () => {
       const starter = makeMockStarter();
       sessionRepo.findByIdAndUserUid.mockResolvedValue(null);
 
-      const useCase = new SendMessageUseCase(sessionRepo, messageRepo, starter);
+      const useCase = new SendMessageUseCase(
+        sessionRepo,
+        messageRepo,
+        starter,
+        makeMockCallback(),
+      );
 
       await expect(
         useCase.execute(
@@ -147,7 +171,12 @@ describe('SendMessageUseCase', () => {
     messageRepo.create.mockResolvedValue(mockUserMessage);
     starter.start.mockResolvedValue(mockExecution);
 
-    const useCase = new SendMessageUseCase(sessionRepo, messageRepo, starter);
+    const useCase = new SendMessageUseCase(
+      sessionRepo,
+      messageRepo,
+      starter,
+      makeMockCallback(),
+    );
     await useCase.execute({ content: 'Hi' }, UID, EMAIL);
 
     expect(sessionRepo.touchLastMessage).toHaveBeenCalledWith('session-1', UID);
@@ -161,7 +190,12 @@ describe('SendMessageUseCase', () => {
     messageRepo.create.mockResolvedValue(mockUserMessage);
     starter.start.mockResolvedValue(mockExecution);
 
-    const useCase = new SendMessageUseCase(sessionRepo, messageRepo, starter);
+    const useCase = new SendMessageUseCase(
+      sessionRepo,
+      messageRepo,
+      starter,
+      makeMockCallback(),
+    );
     const result = await useCase.execute(
       { content: 'Gasté $45 en la cena' },
       UID,
@@ -196,7 +230,12 @@ describe('SendMessageUseCase', () => {
       { ...mockUserMessage, role: 'assistant', content: '¿En qué moneda?' },
     ]);
 
-    const useCase = new SendMessageUseCase(sessionRepo, messageRepo, starter);
+    const useCase = new SendMessageUseCase(
+      sessionRepo,
+      messageRepo,
+      starter,
+      makeMockCallback(),
+    );
     await useCase.execute(
       { sessionId: 'session-1', content: 'en COP' },
       UID,
@@ -228,7 +267,12 @@ describe('SendMessageUseCase', () => {
     });
     starter.start.mockResolvedValue(mockExecution);
 
-    const useCase = new SendMessageUseCase(sessionRepo, messageRepo, starter);
+    const useCase = new SendMessageUseCase(
+      sessionRepo,
+      messageRepo,
+      starter,
+      makeMockCallback(),
+    );
     await useCase.execute(
       {
         content: 'Here is the receipt',
@@ -252,5 +296,91 @@ describe('SendMessageUseCase', () => {
         attachmentType: 'image',
       }),
     );
+  });
+
+  it('supersedes pending previews before starting the new workflow', async () => {
+    const sessionRepo = makeMockSessionRepo();
+    const messageRepo = makeMockMessageRepo();
+    const starter = makeMockStarter();
+    const callback = makeMockCallback();
+    sessionRepo.findByIdAndUserUid.mockResolvedValue(mockSession);
+    messageRepo.create.mockResolvedValue(mockUserMessage);
+    starter.start.mockResolvedValue(mockExecution);
+    messageRepo.findPendingPreviewsBySession.mockResolvedValue([
+      {
+        ...mockUserMessage,
+        id: 'preview-1',
+        role: 'assistant',
+        task_token: 'token-1',
+        task_token_status: 'pending',
+      },
+    ]);
+    messageRepo.updateTaskTokenStatus.mockResolvedValue({
+      ...mockUserMessage,
+      id: 'preview-1',
+      task_token_status: 'superseded',
+    });
+
+    const useCase = new SendMessageUseCase(
+      sessionRepo,
+      messageRepo,
+      starter,
+      callback,
+    );
+    await useCase.execute(
+      { sessionId: 'session-1', content: 'mejor que sean 50' },
+      UID,
+      EMAIL,
+    );
+
+    expect(messageRepo.updateTaskTokenStatus).toHaveBeenCalledWith(
+      'preview-1',
+      UID,
+      'superseded',
+      EMAIL,
+    );
+    expect(callback.resume).toHaveBeenCalledWith('token-1', {
+      confirmed: false,
+      superseded: true,
+    });
+    // The new workflow still starts after the old preview is released.
+    expect(starter.start).toHaveBeenCalled();
+  });
+
+  it('still sends the message if releasing a stale preview fails', async () => {
+    const sessionRepo = makeMockSessionRepo();
+    const messageRepo = makeMockMessageRepo();
+    const starter = makeMockStarter();
+    const callback = makeMockCallback();
+    sessionRepo.findByIdAndUserUid.mockResolvedValue(mockSession);
+    messageRepo.create.mockResolvedValue(mockUserMessage);
+    starter.start.mockResolvedValue(mockExecution);
+    messageRepo.findPendingPreviewsBySession.mockResolvedValue([
+      {
+        ...mockUserMessage,
+        id: 'preview-1',
+        role: 'assistant',
+        task_token: 'token-1',
+        task_token_status: 'pending',
+      },
+    ]);
+    // A concurrent confirm already resolved the token: the guarded update
+    // throws, but the new message must still go through.
+    messageRepo.updateTaskTokenStatus.mockRejectedValue(new Error('no rows'));
+
+    const useCase = new SendMessageUseCase(
+      sessionRepo,
+      messageRepo,
+      starter,
+      callback,
+    );
+    await useCase.execute(
+      { sessionId: 'session-1', content: 'otra cosa' },
+      UID,
+      EMAIL,
+    );
+
+    expect(callback.resume).not.toHaveBeenCalled();
+    expect(starter.start).toHaveBeenCalled();
   });
 });

--- a/services/chat/src/application/use-cases/send-message.use-case.ts
+++ b/services/chat/src/application/use-cases/send-message.use-case.ts
@@ -9,6 +9,7 @@ import type {
   StartChatWorkflowResult,
   WorkflowStarterService,
 } from '@services/chat/domain/services/workflow-starter.service';
+import type { WorkflowCallbackService } from '@services/chat/domain/services/workflow-callback.service';
 import { UnauthorizedError } from '@packages/models/shared/utils/errors';
 
 export interface SendMessageInput {
@@ -72,6 +73,7 @@ export class SendMessageUseCase {
     private readonly sessionRepository: ChatSessionRepository,
     private readonly messageRepository: ChatMessageRepository,
     private readonly workflowStarter: WorkflowStarterService,
+    private readonly workflowCallback: WorkflowCallbackService,
   ) {}
 
   async execute(
@@ -80,6 +82,12 @@ export class SendMessageUseCase {
     userEmail: string,
   ): Promise<SendMessageResult> {
     const session = await this.resolveSession(input.sessionId, uid, userEmail);
+
+    // Sending a new message in a session that still has a pending expense
+    // preview means the user is iterating on it. Release the old preview(s)
+    // silently so only the latest confirmation stays actionable and the
+    // abandoned executions don't fire a false timeout alarm.
+    await this.supersedePendingPreviews(session.id, uid, userEmail);
 
     // Load prior turns BEFORE persisting the current message so the history
     // is context for it (not including it).
@@ -119,6 +127,47 @@ export class SendMessageUseCase {
     });
 
     return { session, userMessage, execution };
+  }
+
+  /**
+   * Marks any still-pending preview in the session as `superseded` and
+   * resumes its paused workflow with `{ confirmed: false, superseded: true }`
+   * so the Choice state ends silently (no expense, no client publish).
+   *
+   * Best-effort per preview: the DB guard makes the status transition atomic
+   * (only `pending` rows flip), and a failed callback for one stale token
+   * must not block the user's new message — the worst case is the old
+   * execution eventually timing out, which is what we already had.
+   */
+  private async supersedePendingPreviews(
+    sessionId: string,
+    uid: string,
+    userEmail: string,
+  ): Promise<void> {
+    const pending = await this.messageRepository.findPendingPreviewsBySession(
+      sessionId,
+      uid,
+    );
+
+    for (const preview of pending) {
+      if (!preview.task_token) continue;
+      try {
+        await this.messageRepository.updateTaskTokenStatus(
+          preview.id,
+          uid,
+          'superseded',
+          userEmail,
+        );
+        await this.workflowCallback.resume(preview.task_token, {
+          confirmed: false,
+          superseded: true,
+        });
+      } catch {
+        // A concurrent confirm/cancel may have already resolved this token,
+        // or the execution may be gone. Skip and continue — the new message
+        // must still go through.
+      }
+    }
   }
 
   private async resolveSession(

--- a/services/chat/src/domain/entities/chat-message.ts
+++ b/services/chat/src/domain/entities/chat-message.ts
@@ -20,12 +20,16 @@ export type ChatMessageAttachmentType = 'image' | 'audio';
  * - `confirmed`: user accepted the preview; the workflow resumed.
  * - `cancelled`: user rejected the preview; the workflow resumed.
  * - `expired`: the task token timed out (Step Function timeout).
+ * - `superseded`: the user iterated on the preview (sent a new message)
+ *   while it was still pending, so its paused workflow was released
+ *   silently and the client shows only the latest preview.
  */
 export type ChatMessageTaskTokenStatus =
   | 'pending'
   | 'confirmed'
   | 'cancelled'
-  | 'expired';
+  | 'expired'
+  | 'superseded';
 
 /**
  * A chat message persisted in `financial_management.chat_messages`.

--- a/services/chat/src/domain/entities/chat-session.ts
+++ b/services/chat/src/domain/entities/chat-session.ts
@@ -21,3 +21,16 @@ export interface ChatSession {
 export interface CreateChatSessionInput {
   metadata?: Record<string, unknown>;
 }
+
+/**
+ * Read model for the sessions list panel (ChatGPT-style sidebar).
+ * `preview` is a snippet of the session's first user message, used as a
+ * human-friendly title. `message_count` lets the client hide empty shells.
+ */
+export interface ChatSessionSummary {
+  id: string;
+  started_at: string;
+  last_message_at: string;
+  preview: string | null;
+  message_count: number;
+}

--- a/services/chat/src/domain/repositories/chat-message.repository.ts
+++ b/services/chat/src/domain/repositories/chat-message.repository.ts
@@ -40,6 +40,17 @@ export interface ChatMessageRepository {
   ): Promise<ChatMessage | null>;
 
   /**
+   * Returns the session's assistant preview messages that are still
+   * `pending` (have a `task_token`). Used when the user iterates on a
+   * preview: each one is superseded so only the latest confirmation
+   * remains actionable. Scoped to the owning user.
+   */
+  findPendingPreviewsBySession(
+    sessionId: string,
+    uid: string,
+  ): Promise<ChatMessage[]>;
+
+  /**
    * Updates the `task_token_status` of a message. Called after the user
    * confirms or cancels (or after timeout reconciliation).
    */

--- a/services/chat/src/domain/repositories/chat-session.repository.ts
+++ b/services/chat/src/domain/repositories/chat-session.repository.ts
@@ -1,5 +1,6 @@
 import type {
   ChatSession,
+  ChatSessionSummary,
   CreateChatSessionInput,
 } from '@services/chat/domain/entities/chat-session';
 
@@ -32,4 +33,11 @@ export interface ChatSessionRepository {
    * Used after a new message is persisted to keep history lists sorted.
    */
   touchLastMessage(id: string, uid: string): Promise<void>;
+
+  /**
+   * Lists the user's sessions for the sidebar, newest activity first.
+   * Only sessions that have at least one message are returned (empty
+   * shells created but never used are skipped). Scoped to the owning user.
+   */
+  findByUser(uid: string, limit: number): Promise<ChatSessionSummary[]>;
 }

--- a/services/chat/src/domain/services/workflow-callback.service.ts
+++ b/services/chat/src/domain/services/workflow-callback.service.ts
@@ -5,6 +5,13 @@
  */
 export interface WorkflowCallbackPayload {
   confirmed: boolean;
+  /**
+   * Set when the preview was released because the user iterated on it
+   * (sent a new message while it was still pending). The Choice state
+   * routes a superseded resume to a silent Succeed — no expense is
+   * created and nothing is published to the client.
+   */
+  superseded?: boolean;
 }
 
 /**

--- a/services/chat/src/infrastructure/repositories/postgres-chat-message.repository.ts
+++ b/services/chat/src/infrastructure/repositories/postgres-chat-message.repository.ts
@@ -89,6 +89,26 @@ export class PostgresChatMessageRepository implements ChatMessageRepository {
     return rows[0] ?? null;
   }
 
+  @trace('ChatMessage:findPendingPreviewsBySession')
+  async findPendingPreviewsBySession(
+    sessionId: string,
+    uid: string,
+  ): Promise<ChatMessage[]> {
+    const rows = await this.dbService.queryReadOnly<ChatMessage>(
+      `SELECT ${MESSAGE_COLUMNS}
+       FROM financial_management.chat_messages m
+       JOIN financial_management.chat_sessions s ON m.session_id = s.id
+       JOIN financial_management.users u ON s.user_id = u.id
+       WHERE m.session_id = $1
+         AND u.uid = $2
+         AND m.task_token IS NOT NULL
+         AND m.task_token_status = 'pending'
+       ORDER BY m.created_at ASC, m.id ASC`,
+      [sessionId, uid],
+    );
+    return rows;
+  }
+
   @trace('ChatMessage:updateTaskTokenStatus')
   async updateTaskTokenStatus(
     id: string,

--- a/services/chat/src/infrastructure/repositories/postgres-chat-session.repository.ts
+++ b/services/chat/src/infrastructure/repositories/postgres-chat-session.repository.ts
@@ -1,5 +1,6 @@
 import type {
   ChatSession,
+  ChatSessionSummary,
   CreateChatSessionInput,
 } from '@services/chat/domain/entities/chat-session';
 import type { ChatSessionRepository } from '@services/chat/domain/repositories/chat-session.repository';
@@ -63,6 +64,37 @@ export class PostgresChatSessionRepository implements ChatSessionRepository {
        SET last_message_at = now()
        WHERE id = $1 AND user_id = ${USER_ID_SUBQUERY}$2)`,
       [id, uid],
+    );
+  }
+
+  @trace('ChatSession:findByUser')
+  async findByUser(uid: string, limit: number): Promise<ChatSessionSummary[]> {
+    // `preview` = the first user message (the closest thing to a title).
+    // `message_count` lets the client skip empty shells; we also filter them
+    // out here so a freshly-created-but-unused session never shows up.
+    return this.dbService.queryReadOnly<ChatSessionSummary>(
+      `SELECT
+         s.id,
+         s.started_at,
+         s.last_message_at,
+         (SELECT m.content
+            FROM financial_management.chat_messages m
+            WHERE m.session_id = s.id AND m.role = 'user'
+            ORDER BY m.created_at ASC, m.id ASC
+            LIMIT 1) AS preview,
+         (SELECT count(*)::int
+            FROM financial_management.chat_messages m
+            WHERE m.session_id = s.id) AS message_count
+       FROM financial_management.chat_sessions s
+       JOIN financial_management.users u ON s.user_id = u.id
+       WHERE u.uid = $1
+         AND EXISTS (
+           SELECT 1 FROM financial_management.chat_messages m
+           WHERE m.session_id = s.id
+         )
+       ORDER BY s.last_message_at DESC
+       LIMIT $2`,
+      [uid, limit],
     );
   }
 }

--- a/services/chat/src/presentation/controller.ts
+++ b/services/chat/src/presentation/controller.ts
@@ -1,6 +1,11 @@
 import type { Application } from '@services/chat/presentation/application';
 import { Controller } from '@services/chat/types/controller';
-import { ChatService, ChatConfirmService } from './service';
+import {
+  ChatService,
+  ChatConfirmService,
+  ChatSessionsService,
+  ChatSessionMessagesService,
+} from './service';
 import { MethodNotImplementedError } from '@packages/models/shared/utils/errors';
 
 /**
@@ -50,6 +55,68 @@ export class ChatConfirmController extends Controller {
 
   override async POST(): Promise<Response> {
     return this.service.executePOST();
+  }
+
+  override PUT(): Promise<Response> {
+    throw new MethodNotImplementedError();
+  }
+
+  override PATCH(): Promise<Response> {
+    throw new MethodNotImplementedError();
+  }
+
+  override DELETE(): Promise<Response> {
+    throw new MethodNotImplementedError();
+  }
+}
+
+/**
+ * Controller for `GET /chat/sessions`. Lists the user's chat sessions
+ * for the sidebar; only GET is supported.
+ */
+export class ChatSessionsController extends Controller {
+  constructor(public override readonly app: Application) {
+    const service = new ChatSessionsService(app);
+    super(app, service);
+  }
+
+  override async GET(): Promise<Response> {
+    return this.service.executeGET();
+  }
+
+  override POST(): Promise<Response> {
+    throw new MethodNotImplementedError();
+  }
+
+  override PUT(): Promise<Response> {
+    throw new MethodNotImplementedError();
+  }
+
+  override PATCH(): Promise<Response> {
+    throw new MethodNotImplementedError();
+  }
+
+  override DELETE(): Promise<Response> {
+    throw new MethodNotImplementedError();
+  }
+}
+
+/**
+ * Controller for `GET /chat/sessions/{id}/messages`. Returns a session's
+ * messages so the client can restore the conversation; only GET supported.
+ */
+export class ChatSessionMessagesController extends Controller {
+  constructor(public override readonly app: Application) {
+    const service = new ChatSessionMessagesService(app);
+    super(app, service);
+  }
+
+  override async GET(): Promise<Response> {
+    return this.service.executeGET();
+  }
+
+  override POST(): Promise<Response> {
+    throw new MethodNotImplementedError();
   }
 
   override PUT(): Promise<Response> {

--- a/services/chat/src/presentation/router.ts
+++ b/services/chat/src/presentation/router.ts
@@ -1,4 +1,9 @@
-import { ChatController, ChatConfirmController } from './controller';
+import {
+  ChatController,
+  ChatConfirmController,
+  ChatSessionsController,
+  ChatSessionMessagesController,
+} from './controller';
 import type { ModuleType } from '@services/chat/types/module';
 import type { Application } from '@services/chat/presentation/application';
 
@@ -10,5 +15,13 @@ export const ROUTES: Array<ModuleType> = [
   {
     url: '/chat/confirm',
     controller: (app: Application) => new ChatConfirmController(app),
+  },
+  {
+    url: '/chat/sessions',
+    controller: (app: Application) => new ChatSessionsController(app),
+  },
+  {
+    url: '/chat/sessions/{id}/messages',
+    controller: (app: Application) => new ChatSessionMessagesController(app),
   },
 ];

--- a/services/chat/src/presentation/service.ts
+++ b/services/chat/src/presentation/service.ts
@@ -2,6 +2,8 @@ import { Service } from '@services/chat/types/service';
 import type { Application } from '@services/chat/presentation/application';
 import { SendMessageUseCase } from '@services/chat/application/use-cases/send-message.use-case';
 import { ConfirmPendingExpenseUseCase } from '@services/chat/application/use-cases/confirm-pending-expense.use-case';
+import { ListSessionsUseCase } from '@services/chat/application/use-cases/list-sessions.use-case';
+import { GetSessionMessagesUseCase } from '@services/chat/application/use-cases/get-session-messages.use-case';
 import { PostgresChatSessionRepository } from '@services/chat/infrastructure/repositories/postgres-chat-session.repository';
 import { PostgresChatMessageRepository } from '@services/chat/infrastructure/repositories/postgres-chat-message.repository';
 import { DataNotDefinedError } from '@packages/models/shared/utils/errors';
@@ -54,6 +56,7 @@ export class ChatService extends Service {
       sessionRepository,
       messageRepository,
       this.app.workflowStarter,
+      this.app.workflowCallback,
     );
 
     const result = await useCase.execute(
@@ -140,6 +143,78 @@ export class ChatConfirmService extends Service {
           messageId: result.message.id,
         },
       }),
+      { status: HttpCode.SUCCESS },
+    );
+  }
+}
+
+/**
+ * Service for `GET /chat/sessions`.
+ *
+ * Lists the authenticated user's chat sessions (newest activity first)
+ * so the client can render the sessions sidebar and switch between them.
+ */
+export class ChatSessionsService extends Service {
+  constructor(public readonly app: Application) {
+    super(app);
+  }
+
+  override async executeGET(): Promise<Response> {
+    this.app.logger.info(
+      'Executing chat sessions GET request',
+      ChatSessionsService.name,
+    );
+
+    const sessionRepository = new PostgresChatSessionRepository(
+      this.app.dbService,
+    );
+    const useCase = new ListSessionsUseCase(sessionRepository);
+
+    const sessions = await useCase.execute(this.app.user.uid);
+
+    return new Response(JSON.stringify({ success: true, data: { sessions } }), {
+      status: HttpCode.SUCCESS,
+    });
+  }
+}
+
+/**
+ * Service for `GET /chat/sessions/{id}/messages`.
+ *
+ * Returns a session's messages (oldest → newest) so the client can
+ * restore the conversation on reload or when switching sessions.
+ */
+export class ChatSessionMessagesService extends Service {
+  constructor(public readonly app: Application) {
+    super(app);
+  }
+
+  override async executeGET(): Promise<Response> {
+    this.app.logger.info(
+      'Executing chat session messages GET request',
+      ChatSessionMessagesService.name,
+    );
+
+    const sessionId = this.app.event.pathParameters?.['id'];
+    if (!sessionId) {
+      throw new DataNotDefinedError('session id is required');
+    }
+
+    const sessionRepository = new PostgresChatSessionRepository(
+      this.app.dbService,
+    );
+    const messageRepository = new PostgresChatMessageRepository(
+      this.app.dbService,
+    );
+    const useCase = new GetSessionMessagesUseCase(
+      sessionRepository,
+      messageRepository,
+    );
+
+    const messages = await useCase.execute(sessionId, this.app.user.uid);
+
+    return new Response(
+      JSON.stringify({ success: true, data: { sessionId, messages } }),
       { status: HttpCode.SUCCESS },
     );
   }

--- a/services/chat/src/test/chat-messages.integration.test.ts
+++ b/services/chat/src/test/chat-messages.integration.test.ts
@@ -177,6 +177,75 @@ describe('PostgresChatMessageRepository — integration', () => {
     });
   });
 
+  describe('findPendingPreviewsBySession', () => {
+    it('returns only pending previews of the session (oldest → newest)', async () => {
+      const first = await repo.create(
+        {
+          session_id: session.id,
+          role: 'assistant',
+          content: 'preview 1',
+          task_token: 'tok-1',
+          task_token_status: 'pending',
+        },
+        'chat-workflow',
+      );
+      const second = await repo.create(
+        {
+          session_id: session.id,
+          role: 'assistant',
+          content: 'preview 2',
+          task_token: 'tok-2',
+          task_token_status: 'pending',
+        },
+        'chat-workflow',
+      );
+      // A plain user message and an already-confirmed preview must be excluded.
+      await repo.create(
+        { session_id: session.id, role: 'user', content: 'hola' },
+        userA.email,
+      );
+      const confirmed = await repo.create(
+        {
+          session_id: session.id,
+          role: 'assistant',
+          content: 'preview confirmado',
+          task_token: 'tok-3',
+          task_token_status: 'pending',
+        },
+        'chat-workflow',
+      );
+      await repo.updateTaskTokenStatus(
+        confirmed.id,
+        userA.uid,
+        'confirmed',
+        userA.email,
+      );
+
+      const pending = await repo.findPendingPreviewsBySession(
+        session.id,
+        userA.uid,
+      );
+      expect(pending.map((m) => m.id)).toEqual([first.id, second.id]);
+    });
+
+    it('does NOT return previews for another user', async () => {
+      await repo.create(
+        {
+          session_id: session.id,
+          role: 'assistant',
+          content: 'preview',
+          task_token: 'tok-1',
+          task_token_status: 'pending',
+        },
+        'chat-workflow',
+      );
+
+      expect(
+        await repo.findPendingPreviewsBySession(session.id, userB.uid),
+      ).toEqual([]);
+    });
+  });
+
   describe('updateTaskTokenStatus', () => {
     it('updates the status for the owning user', async () => {
       const created = await repo.create(

--- a/services/chat/src/test/chat-sessions.integration.test.ts
+++ b/services/chat/src/test/chat-sessions.integration.test.ts
@@ -104,4 +104,57 @@ describe('PostgresChatSessionRepository — integration', () => {
       expect(delta).toBeGreaterThan(60_000);
     });
   });
+
+  describe('findByUser', () => {
+    const insertMessage = async (
+      sessionId: string,
+      role: string,
+      content: string,
+    ) => {
+      await dbService.query(
+        `INSERT INTO financial_management.chat_messages
+           (session_id, role, content, created_by, modified_by)
+         VALUES ($1, $2, $3, 'test', 'test')`,
+        [sessionId, role, content],
+      );
+    };
+
+    it('lists sessions newest-activity-first with a first-user-message preview', async () => {
+      const older = await repo.create({}, userA.uid, userA.email);
+      await insertMessage(older.id, 'user', '¿Cuánto gasté este mes?');
+      await dbService.query(
+        `UPDATE financial_management.chat_sessions
+         SET last_message_at = now() - interval '1 hour' WHERE id = $1`,
+        [older.id],
+      );
+
+      const newer = await repo.create({}, userA.uid, userA.email);
+      await insertMessage(newer.id, 'user', 'Gasté 50 en el super');
+      await insertMessage(newer.id, 'assistant', 'Listo, lo registré');
+
+      const sessions = await repo.findByUser(userA.uid, 50);
+
+      expect(sessions.map((s) => s.id)).toEqual([newer.id, older.id]);
+      expect(sessions[0]?.preview).toBe('Gasté 50 en el super');
+      expect(sessions[0]?.message_count).toBe(2);
+    });
+
+    it('excludes empty sessions (no messages)', async () => {
+      const empty = await repo.create({}, userA.uid, userA.email);
+      const withMessage = await repo.create({}, userA.uid, userA.email);
+      await insertMessage(withMessage.id, 'user', 'hola');
+
+      const sessions = await repo.findByUser(userA.uid, 50);
+
+      expect(sessions.map((s) => s.id)).toEqual([withMessage.id]);
+      expect(sessions.map((s) => s.id)).not.toContain(empty.id);
+    });
+
+    it("does NOT return another user's sessions", async () => {
+      const sessionB = await repo.create({}, userB.uid, userB.email);
+      await insertMessage(sessionB.id, 'user', 'secreto');
+
+      expect(await repo.findByUser(userA.uid, 50)).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Three improvements to the AI chat, shipped together:

1. **Preview iteration** — iterating on an expense preview (sending a new message while one is still pending) no longer leaves a duplicate Confirm/Cancel. The previous preview is *superseded*: its paused Step Functions execution is released silently (no expense, no publish) and only the latest confirmation stays actionable. This also stops abandoned previews from firing a false `ExecutionsTimedOut` alarm.
2. **Typing indicator** — the plain "Processing…" text is replaced with an animated typing indicator (assistant-style bubble with pulsing dots).
3. **Session management** (ChatGPT-style, no expiry) — the last session is restored on reload/reopen, a sessions list lets you switch conversations, and a "New chat" action starts a fresh one.

### Core Changes

- **Supersede flow**: `send-message` use case finds pending previews for the session, marks them `superseded` (atomic, guarded transition) and resumes their workflow with `{ confirmed: false, superseded: true }`; best-effort so a stale token never blocks the new message.
- **ChatProcess ASL**: the `Confirmed?` choice routes a superseded resume to a silent `Succeed` (guarded with `isPresent` so a normal confirm is unaffected).
- **TypingIndicator** atom in `@features/ui`; drawer renders Confirm/Cancel only for the latest pending preview.
- **Session persistence** via `@packages/utils` `preferenceStorage` (AsyncStorage, per-user key); sessions list panel + New chat in the drawer.

### API / Data Changes

- **Migration 4.1.0**: adds `'superseded'` to the `chat_messages.task_token_status` CHECK (down-migration normalizes superseded rows to `cancelled`). **Must run on dev before/with deploy.**
- **New routes** (Cognito-authed, `authOnly`):
  - `GET /chat/sessions` → list sessions (`{ id, started_at, last_message_at, preview, message_count }`, newest first, empty shells excluded)
  - `GET /chat/sessions/{id}/messages` → restore a conversation (ownership-checked)
- **New env vars**: none.
- Requires redeploying **StepFunctionsChat** (ASL change) and **LambdaChat** (new routes).

## Type of Change

- [x] Feature (new functionality)

## How to Test

1. Run migration 4.1.0 on dev (`pnpm migrations:migrate`) and deploy StepFunctionsChat + LambdaChat.
2. In the app, log an expense by chat → on the preview, send a *new* message refining it (e.g. "mejor que sean 50"). Expect: the old Confirm/Cancel disappears and only the new preview is actionable; no duplicate confirmation.
3. While the bot is working, expect the animated typing indicator (not "Processing…").
4. Reload the page / navigate away and back → the last conversation is restored.
5. Open the sessions list (history icon), switch between sessions, and use "New chat" to start a fresh one.

## Checklist

- [x] PR description includes clear testing instructions
- [x] Self-reviewed the code for readability and correctness
- [x] No new warnings in format, lint, typecheck, or test
- [x] PR has the correct type label assigned

### Tests

- [x] Added or updated tests covering the changes (unit + integration for the supersede flow, session list/messages use cases & repos, infra stack route coverage, TypingIndicator, preferenceStorage, chat API adapter). Full suite, lint, typecheck and format pass locally.

### Project Structure

- [x] New client features are placed in `client/packages/features/`
- [x] New CDK changes follow versioning (`infra/lib/versions/v2`)
- [x] Shared config changes are reflected across dependent packages

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)