### PR TITLE
fix: auto-reconnect chat realtime socket (replies lost on long sessions)

### DIFF
--- a/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.test.ts
+++ b/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.test.ts
@@ -39,6 +39,16 @@ class StubSocket {
       } as MessageEvent,
     );
   }
+  simulateClose() {
+    this.onclose?.call(this as unknown as WebSocket, {} as CloseEvent);
+  }
+}
+
+/** Drives an open socket through the full handshake to subscribe_success. */
+async function handshake(ws: StubSocket) {
+  ws.simulateOpen();
+  ws.simulateMessage({ type: 'connection_ack' });
+  ws.simulateMessage({ type: 'subscribe_success' });
 }
 
 beforeAll(() => {
@@ -106,6 +116,7 @@ describe('AppSyncEventsClient', () => {
 
     ws.simulateMessage({ type: 'subscribe_success' });
     await expect(subscribePromise).resolves.toBeUndefined();
+    client.close();
   });
 
   it('forwards parsed chat events to the listener', async () => {
@@ -134,6 +145,7 @@ describe('AppSyncEventsClient', () => {
     });
 
     expect(listener).toHaveBeenCalledWith(event);
+    client.close();
   });
 
   it('rejects subscribe() when getToken returns null', async () => {
@@ -164,5 +176,66 @@ describe('AppSyncEventsClient', () => {
 
     ws.simulateMessage({ type: 'error', errors: ['boom'] });
     expect(onError).toHaveBeenCalled();
+    client.close();
+  });
+
+  it('reconnects after an unexpected close and fires onReconnect on re-subscribe', async () => {
+    jest.useFakeTimers();
+    try {
+      const onReconnect = jest.fn();
+      const client = new AppSyncEventsClient({ ...baseConfig, onReconnect });
+      const listener = jest.fn();
+
+      const subscribePromise = client.subscribe(listener);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const ws1 = StubSocket.last!;
+      await handshake(ws1);
+      await subscribePromise;
+      // First subscribe must NOT be treated as a reconnect.
+      expect(onReconnect).not.toHaveBeenCalled();
+
+      // The socket drops unexpectedly → client schedules a reconnect.
+      ws1.simulateClose();
+      jest.advanceTimersByTime(1000); // first backoff step
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const ws2 = StubSocket.last!;
+      expect(ws2).not.toBe(ws1);
+      await handshake(ws2);
+
+      // A successful re-subscribe triggers the backfill hook exactly once.
+      expect(onReconnect).toHaveBeenCalledTimes(1);
+
+      client.close();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not reconnect after an intentional close()', async () => {
+    jest.useFakeTimers();
+    try {
+      const client = new AppSyncEventsClient({ ...baseConfig });
+      const subscribePromise = client.subscribe(jest.fn());
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const ws1 = StubSocket.last!;
+      await handshake(ws1);
+      await subscribePromise;
+
+      client.close();
+      ws1.simulateClose();
+      jest.advanceTimersByTime(5000);
+      await Promise.resolve();
+
+      // No new socket was created after an intentional close.
+      expect(StubSocket.last).toBe(ws1);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.test.ts
+++ b/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.test.ts
@@ -21,11 +21,16 @@ class StubSocket {
     StubSocket.last = this;
   }
 
+  closeCalls = 0;
+
   send(data: string) {
     this.sent.push(data);
   }
   close() {
-    /* no-op */
+    // Mirror a real WebSocket: closing fires `onclose` so the client's
+    // reconnect path runs.
+    this.closeCalls += 1;
+    this.onclose?.call(this as unknown as WebSocket, {} as CloseEvent);
   }
 
   simulateOpen() {
@@ -208,6 +213,42 @@ describe('AppSyncEventsClient', () => {
 
       // A successful re-subscribe triggers the backfill hook exactly once.
       expect(onReconnect).toHaveBeenCalledTimes(1);
+
+      client.close();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('forces a reconnect when no keep-alive arrives within the idle window', async () => {
+    jest.useFakeTimers();
+    try {
+      const client = new AppSyncEventsClient({ ...baseConfig });
+      const subscribePromise = client.subscribe(jest.fn());
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const ws1 = StubSocket.last!;
+      ws1.simulateOpen();
+      // Server advertises a 1s idle timeout on connection_ack.
+      ws1.simulateMessage({
+        type: 'connection_ack',
+        connectionTimeoutMs: 1000,
+      });
+      ws1.simulateMessage({ type: 'subscribe_success' });
+      await subscribePromise;
+
+      // No further frames (no keep-alive): advance past idleTimeout + grace.
+      jest.advanceTimersByTime(1000 + 10_000 + 1);
+      expect(ws1.closeCalls).toBeGreaterThan(0); // watchdog closed the socket
+
+      // The close schedules a reconnect; advance the backoff and let it run.
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const ws2 = StubSocket.last!;
+      expect(ws2).not.toBe(ws1);
 
       client.close();
     } finally {

--- a/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.ts
+++ b/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.ts
@@ -33,6 +33,11 @@ const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
 /** Fallback idle watchdog if the server doesn't advertise a timeout. */
 const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+/**
+ * Buffer added on top of the idle timeout before declaring the socket dead,
+ * so the watchdog never preempts a keep-alive that's merely a little late.
+ */
+const IDLE_GRACE_MS = 10_000;
 
 /**
  * Minimal AppSync Events WebSocket client with auto-reconnect.
@@ -64,21 +69,49 @@ export class AppSyncEventsClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   private idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS;
+  // Settles the promise returned by `subscribe()`. Resolved on the FIRST
+  // successful subscription (even if it took a few reconnect attempts) and
+  // rejected only on a terminal failure (no auth token) — so the caller never
+  // hangs forever when the socket drops mid-handshake.
+  private ready: {
+    resolve: () => void;
+    reject: (error: unknown) => void;
+  } | null = null;
+  private readySettled = false;
 
   constructor(private readonly config: AppSyncEventsConfig) {}
 
-  /** Connect, authenticate, and subscribe. Resolves once the subscription is ack'ed. */
-  async subscribe(listener: (event: ChatEvent) => void): Promise<void> {
+  /**
+   * Connect, authenticate, and subscribe. Resolves once the subscription is
+   * ack'ed; transient drops while connecting are retried transparently rather
+   * than rejecting (so the promise resolves as soon as we're connected).
+   */
+  subscribe(listener: (event: ChatEvent) => void): Promise<void> {
     this.listener = listener;
     this.closed = false;
     this.reconnectAttempts = 0;
     this.hasSubscribedOnce = false;
-    await this.connect();
+    this.readySettled = false;
+    return new Promise<void>((resolve, reject) => {
+      this.ready = { resolve, reject };
+      void this.connect();
+    });
+  }
+
+  /** Settles the `subscribe()` promise exactly once. */
+  private settleReady(error?: unknown): void {
+    if (this.readySettled || !this.ready) return;
+    this.readySettled = true;
+    if (error !== undefined) this.ready.reject(error);
+    else this.ready.resolve();
   }
 
   /** Close the socket. Safe to call multiple times. */
   close(): void {
     this.closed = true;
+    // Settle a still-pending subscribe() so an awaiting caller never hangs
+    // when the drawer closes before the first subscription completes.
+    this.settleReady(new Error('AppSync subscription closed'));
     this.clearReconnectTimer();
     this.clearIdleTimer();
     if (this.socket) {
@@ -93,92 +126,100 @@ export class AppSyncEventsClient {
     this.subscriptionId = null;
   }
 
-  private connect(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      void (async () => {
-        const token = await this.config.getToken();
-        if (!token) {
-          reject(
-            new Error('Missing Cognito token for AppSync Events subscription'),
-          );
-          return;
+  private async connect(): Promise<void> {
+    let token: string | null;
+    try {
+      token = await this.config.getToken();
+    } catch (err) {
+      // Transient token fetch failure — surface it and retry.
+      this.config.onError?.(err);
+      this.scheduleReconnect();
+      return;
+    }
+    if (!token) {
+      // No token at all (logged out) is terminal: reject the initial
+      // subscribe and stop — retrying without credentials would loop forever.
+      this.settleReady(
+        new Error('Missing Cognito token for AppSync Events subscription'),
+      );
+      return;
+    }
+
+    // The auth object's `host` must be the HTTP endpoint domain, even though
+    // we connect to the realtime endpoint. For standard AppSync domains that
+    // means swapping the subdomain; for custom domains both share a host so
+    // the replace is a no-op.
+    const host = this.config.realtimeDns.replace(
+      'appsync-realtime-api',
+      'appsync-api',
+    );
+    const authHeader = { host, Authorization: token };
+    const url = `wss://${this.config.realtimeDns}/event/realtime`;
+    const authSubprotocol = `header-${base64UrlEncode(
+      JSON.stringify(authHeader),
+    )}`;
+
+    const ws = new WebSocket(url, [EVENT_WS_SUBPROTOCOL, authSubprotocol]);
+    this.socket = ws;
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: 'connection_init' }));
+    };
+
+    ws.onerror = (err) => {
+      // Don't settle/reject here — `onclose` follows and drives the retry, so
+      // the subscribe() promise resolves once a (re)connection succeeds.
+      this.config.onError?.(err);
+    };
+
+    ws.onmessage = (msgEvent) => {
+      // Any inbound frame (including `ka` keep-alives) proves the link is
+      // alive — reset the idle watchdog.
+      this.resetIdleTimer();
+
+      let parsed: InternalMessage;
+      try {
+        parsed = JSON.parse(String(msgEvent.data)) as InternalMessage;
+      } catch {
+        return;
+      }
+
+      if (parsed.type === 'connection_ack') {
+        if (typeof parsed.connectionTimeoutMs === 'number') {
+          this.idleTimeoutMs = parsed.connectionTimeoutMs;
         }
+        this.resetIdleTimer();
+        this.sendSubscribe(authHeader);
+        return;
+      }
+      if (parsed.type === 'subscribe_success') {
+        this.reconnectAttempts = 0;
+        const wasReconnect = this.hasSubscribedOnce;
+        this.hasSubscribedOnce = true;
+        this.settleReady();
+        // After a reconnect, replay-from-DB so nothing delivered during the
+        // gap is lost.
+        if (wasReconnect) this.config.onReconnect?.();
+        return;
+      }
+      if (parsed.type === 'data') {
+        this.handleData(parsed);
+        return;
+      }
+      if (parsed.type === 'error' || parsed.errors) {
+        this.config.onError?.(parsed);
+      }
+    };
 
-        // The auth object's `host` must be the HTTP endpoint domain, even
-        // though we connect to the realtime endpoint. For standard AppSync
-        // domains that means swapping the subdomain; for custom domains both
-        // share a host so the replace is a no-op.
-        const host = this.config.realtimeDns.replace(
-          'appsync-realtime-api',
-          'appsync-api',
-        );
-        const authHeader = { host, Authorization: token };
-        const url = `wss://${this.config.realtimeDns}/event/realtime`;
-        const authSubprotocol = `header-${base64UrlEncode(
-          JSON.stringify(authHeader),
-        )}`;
-
-        const ws = new WebSocket(url, [EVENT_WS_SUBPROTOCOL, authSubprotocol]);
-        this.socket = ws;
-
-        ws.onopen = () => {
-          ws.send(JSON.stringify({ type: 'connection_init' }));
-        };
-
-        ws.onerror = (err) => {
-          this.config.onError?.(err);
-          reject(err);
-        };
-
-        ws.onmessage = (msgEvent) => {
-          // Any inbound frame (including `ka` keep-alives) proves the link is
-          // alive — reset the idle watchdog.
-          this.resetIdleTimer();
-
-          let parsed: InternalMessage;
-          try {
-            parsed = JSON.parse(String(msgEvent.data)) as InternalMessage;
-          } catch {
-            return;
-          }
-
-          if (parsed.type === 'connection_ack') {
-            if (typeof parsed.connectionTimeoutMs === 'number') {
-              this.idleTimeoutMs = parsed.connectionTimeoutMs;
-            }
-            this.resetIdleTimer();
-            this.sendSubscribe(authHeader);
-            return;
-          }
-          if (parsed.type === 'subscribe_success') {
-            this.reconnectAttempts = 0;
-            const wasReconnect = this.hasSubscribedOnce;
-            this.hasSubscribedOnce = true;
-            resolve();
-            // After a reconnect, replay-from-DB so nothing delivered during
-            // the gap is lost.
-            if (wasReconnect) this.config.onReconnect?.();
-            return;
-          }
-          if (parsed.type === 'data') {
-            this.handleData(parsed);
-            return;
-          }
-          if (parsed.type === 'error' || parsed.errors) {
-            this.config.onError?.(parsed);
-          }
-        };
-
-        ws.onclose = () => {
-          this.clearIdleTimer();
-          if (!this.closed) {
-            // Unexpected drop — reconnect with a fresh token instead of
-            // leaving the chat silently dead.
-            this.scheduleReconnect();
-          }
-        };
-      })().catch((err) => reject(err));
-    });
+    ws.onclose = () => {
+      this.clearIdleTimer();
+      if (!this.closed) {
+        // Unexpected drop (possibly mid-handshake, before subscribe_success) —
+        // reconnect with a fresh token instead of leaving the chat silently
+        // dead. The pending subscribe() promise resolves on the next success.
+        this.scheduleReconnect();
+      }
+    };
   }
 
   private scheduleReconnect(): void {
@@ -191,19 +232,16 @@ export class AppSyncEventsClient {
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       if (this.closed || !this.listener) return;
-      this.connect().catch((err) => {
-        this.config.onError?.(err);
-        // connect() failed before a socket could emit `close`; retry.
-        this.scheduleReconnect();
-      });
+      void this.connect();
     }, delay);
   }
 
   private resetIdleTimer(): void {
     this.clearIdleTimer();
     if (this.closed) return;
-    // Grace beyond the server's keep-alive cadence before declaring the
-    // socket dead and forcing a reconnect.
+    // Wait the server-advertised idle timeout (or the default) plus a grace
+    // buffer before declaring the socket dead and forcing a reconnect — the
+    // server sends keep-alives well within this window.
     this.idleTimer = setTimeout(() => {
       if (this.closed) return;
       try {
@@ -211,7 +249,7 @@ export class AppSyncEventsClient {
       } catch {
         // best effort — onclose triggers the reconnect
       }
-    }, this.idleTimeoutMs);
+    }, this.idleTimeoutMs + IDLE_GRACE_MS);
   }
 
   private clearIdleTimer(): void {

--- a/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.ts
+++ b/client/packages/features/dashboard/src/infrastructure/realtime/appsync-events-client.ts
@@ -11,6 +11,12 @@ export interface AppSyncEventsConfig {
   getToken: () => Promise<string | null>;
   /** Bubbled up to the caller so it can render an error state. */
   onError?: (error: unknown) => void;
+  /**
+   * Called after the socket transparently re-subscribes following a drop.
+   * The drawer uses it to backfill any messages it missed while offline
+   * (AppSync Events does not replay events delivered during the gap).
+   */
+  onReconnect?: () => void;
 }
 
 interface InternalMessage {
@@ -18,12 +24,18 @@ interface InternalMessage {
   errors?: unknown;
   event?: string | string[];
   id?: string;
+  connectionTimeoutMs?: number;
 }
 
 const EVENT_WS_SUBPROTOCOL = 'aws-appsync-event-ws';
+/** Reconnect backoff: starts here, doubles, capped at MAX. */
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+/** Fallback idle watchdog if the server doesn't advertise a timeout. */
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
 
 /**
- * Minimal AppSync Events WebSocket client.
+ * Minimal AppSync Events WebSocket client with auto-reconnect.
  *
  * Per the Events API protocol, auth travels in a WebSocket SUBPROTOCOL
  * (browsers can't set custom headers), NOT in the query string:
@@ -34,6 +46,12 @@ const EVENT_WS_SUBPROTOCOL = 'aws-appsync-event-ws';
  *   3. Send a `subscribe` with the channel + the same authorization object —
  *      the server pushes `data` messages we forward to the listener.
  *
+ * Long-lived chat sessions outlive a single socket: the connection drops on
+ * network blips, idle timeouts, or Cognito token expiry. This client detects
+ * that (unexpected close OR no keep-alive within the server's timeout) and
+ * transparently reconnects with a FRESH token, then re-subscribes — so the
+ * assistant's replies keep arriving without the user reloading the page.
+ *
  * @see https://docs.aws.amazon.com/appsync/latest/eventapi/event-api-websocket-protocol.html
  */
 export class AppSyncEventsClient {
@@ -41,6 +59,11 @@ export class AppSyncEventsClient {
   private subscriptionId: string | null = null;
   private listener: ((event: ChatEvent) => void) | null = null;
   private closed = false;
+  private hasSubscribedOnce = false;
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS;
 
   constructor(private readonly config: AppSyncEventsConfig) {}
 
@@ -48,76 +71,16 @@ export class AppSyncEventsClient {
   async subscribe(listener: (event: ChatEvent) => void): Promise<void> {
     this.listener = listener;
     this.closed = false;
-
-    const token = await this.config.getToken();
-    if (!token) {
-      throw new Error('Missing Cognito token for AppSync Events subscription');
-    }
-
-    // The auth object's `host` must be the HTTP endpoint domain, even though
-    // we connect to the realtime endpoint. For standard AppSync domains that
-    // means swapping the subdomain; for custom domains both share a host so
-    // the replace is a no-op.
-    const host = this.config.realtimeDns.replace(
-      'appsync-realtime-api',
-      'appsync-api',
-    );
-    const authHeader = {
-      host,
-      Authorization: token,
-    };
-    const url = `wss://${this.config.realtimeDns}/event/realtime`;
-    const authSubprotocol = `header-${base64UrlEncode(JSON.stringify(authHeader))}`;
-
-    await new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(url, [EVENT_WS_SUBPROTOCOL, authSubprotocol]);
-      this.socket = ws;
-
-      ws.onopen = () => {
-        ws.send(JSON.stringify({ type: 'connection_init' }));
-      };
-
-      ws.onerror = (err) => {
-        this.config.onError?.(err);
-        reject(err);
-      };
-
-      ws.onmessage = (msgEvent) => {
-        let parsed: InternalMessage;
-        try {
-          parsed = JSON.parse(String(msgEvent.data)) as InternalMessage;
-        } catch {
-          return;
-        }
-
-        if (parsed.type === 'connection_ack') {
-          this.sendSubscribe(authHeader);
-          return;
-        }
-        if (parsed.type === 'subscribe_success') {
-          resolve();
-          return;
-        }
-        if (parsed.type === 'data') {
-          this.handleData(parsed);
-          return;
-        }
-        if (parsed.type === 'error' || parsed.errors) {
-          this.config.onError?.(parsed);
-        }
-      };
-
-      ws.onclose = () => {
-        if (!this.closed) {
-          this.config.onError?.(new Error('AppSync WebSocket closed'));
-        }
-      };
-    });
+    this.reconnectAttempts = 0;
+    this.hasSubscribedOnce = false;
+    await this.connect();
   }
 
   /** Close the socket. Safe to call multiple times. */
   close(): void {
     this.closed = true;
+    this.clearReconnectTimer();
+    this.clearIdleTimer();
     if (this.socket) {
       try {
         this.socket.close();
@@ -128,6 +91,141 @@ export class AppSyncEventsClient {
     }
     this.listener = null;
     this.subscriptionId = null;
+  }
+
+  private connect(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      void (async () => {
+        const token = await this.config.getToken();
+        if (!token) {
+          reject(
+            new Error('Missing Cognito token for AppSync Events subscription'),
+          );
+          return;
+        }
+
+        // The auth object's `host` must be the HTTP endpoint domain, even
+        // though we connect to the realtime endpoint. For standard AppSync
+        // domains that means swapping the subdomain; for custom domains both
+        // share a host so the replace is a no-op.
+        const host = this.config.realtimeDns.replace(
+          'appsync-realtime-api',
+          'appsync-api',
+        );
+        const authHeader = { host, Authorization: token };
+        const url = `wss://${this.config.realtimeDns}/event/realtime`;
+        const authSubprotocol = `header-${base64UrlEncode(
+          JSON.stringify(authHeader),
+        )}`;
+
+        const ws = new WebSocket(url, [EVENT_WS_SUBPROTOCOL, authSubprotocol]);
+        this.socket = ws;
+
+        ws.onopen = () => {
+          ws.send(JSON.stringify({ type: 'connection_init' }));
+        };
+
+        ws.onerror = (err) => {
+          this.config.onError?.(err);
+          reject(err);
+        };
+
+        ws.onmessage = (msgEvent) => {
+          // Any inbound frame (including `ka` keep-alives) proves the link is
+          // alive — reset the idle watchdog.
+          this.resetIdleTimer();
+
+          let parsed: InternalMessage;
+          try {
+            parsed = JSON.parse(String(msgEvent.data)) as InternalMessage;
+          } catch {
+            return;
+          }
+
+          if (parsed.type === 'connection_ack') {
+            if (typeof parsed.connectionTimeoutMs === 'number') {
+              this.idleTimeoutMs = parsed.connectionTimeoutMs;
+            }
+            this.resetIdleTimer();
+            this.sendSubscribe(authHeader);
+            return;
+          }
+          if (parsed.type === 'subscribe_success') {
+            this.reconnectAttempts = 0;
+            const wasReconnect = this.hasSubscribedOnce;
+            this.hasSubscribedOnce = true;
+            resolve();
+            // After a reconnect, replay-from-DB so nothing delivered during
+            // the gap is lost.
+            if (wasReconnect) this.config.onReconnect?.();
+            return;
+          }
+          if (parsed.type === 'data') {
+            this.handleData(parsed);
+            return;
+          }
+          if (parsed.type === 'error' || parsed.errors) {
+            this.config.onError?.(parsed);
+          }
+        };
+
+        ws.onclose = () => {
+          this.clearIdleTimer();
+          if (!this.closed) {
+            // Unexpected drop — reconnect with a fresh token instead of
+            // leaving the chat silently dead.
+            this.scheduleReconnect();
+          }
+        };
+      })().catch((err) => reject(err));
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closed || this.reconnectTimer) return;
+    const delay = Math.min(
+      RECONNECT_BASE_MS * 2 ** this.reconnectAttempts,
+      RECONNECT_MAX_MS,
+    );
+    this.reconnectAttempts += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.closed || !this.listener) return;
+      this.connect().catch((err) => {
+        this.config.onError?.(err);
+        // connect() failed before a socket could emit `close`; retry.
+        this.scheduleReconnect();
+      });
+    }, delay);
+  }
+
+  private resetIdleTimer(): void {
+    this.clearIdleTimer();
+    if (this.closed) return;
+    // Grace beyond the server's keep-alive cadence before declaring the
+    // socket dead and forcing a reconnect.
+    this.idleTimer = setTimeout(() => {
+      if (this.closed) return;
+      try {
+        this.socket?.close();
+      } catch {
+        // best effort — onclose triggers the reconnect
+      }
+    }, this.idleTimeoutMs);
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
   }
 
   private sendSubscribe(authHeader: Record<string, string>): void {

--- a/client/packages/features/dashboard/src/presentation/components/shared/organisms/ai-chat-drawer/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/organisms/ai-chat-drawer/index.tsx
@@ -205,6 +205,26 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
     }).start(() => onClose());
   }, [slideAnim, drawerWidth, onClose]);
 
+  // After the realtime socket transparently reconnects, backfill the active
+  // session from the DB (AppSync Events doesn't replay messages delivered
+  // while we were offline) and clear any transient error banner. Silent — no
+  // restore skeleton — so it doesn't disrupt an ongoing conversation.
+  const handleRealtimeReconnect = useCallback(() => {
+    setErrorBanner(null);
+    const id = sessionIdRef.current;
+    if (!id) return;
+    chatRepository
+      .getSessionMessages(id)
+      .then((history) => {
+        if (!history.length) return;
+        const mapped = mapHistory(history);
+        setMessages(mapped);
+        const last = mapped[mapped.length - 1];
+        if (last && !last.isUser) setIsWaitingForAssistant(false);
+      })
+      .catch((err) => console.warn('Failed to backfill on reconnect', err));
+  }, [chatRepository, mapHistory]);
+
   // ── Real-time subscription ────────────────────────────────
   useEffect(() => {
     if (!visible) return undefined;
@@ -218,6 +238,7 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
         console.warn('AppSync events error', err);
         setErrorBanner(t('aiChat.error'));
       },
+      onReconnect: handleRealtimeReconnect,
     });
 
     const onEvent = (event: ChatEvent) => {
@@ -264,7 +285,15 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
     return () => {
       client.close();
     };
-  }, [visible, appSyncRealtimeDns, appSyncNamespace, userId, getAuthToken, t]);
+  }, [
+    visible,
+    appSyncRealtimeDns,
+    appSyncNamespace,
+    userId,
+    getAuthToken,
+    handleRealtimeReconnect,
+    t,
+  ]);
 
   // ── Send message ──────────────────────────────────────────
   const handleSend = useCallback(async () => {

--- a/client/packages/features/dashboard/src/presentation/components/shared/organisms/ai-chat-drawer/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/organisms/ai-chat-drawer/index.tsx
@@ -216,6 +216,9 @@ export function AIChatDrawer({ visible, onClose }: AIChatDrawerProps) {
     chatRepository
       .getSessionMessages(id)
       .then((history) => {
+        // The user may have switched sessions while this was in flight —
+        // only apply the backfill if it still matches the active session.
+        if (sessionIdRef.current !== id) return;
         if (!history.length) return;
         const mapped = mapHistory(history);
         setMessages(mapped);


### PR DESCRIPTION
## Description

Causa raíz del **typing indicator infinito / "la respuesta solo aparece al recargar"** (y del error "Something went wrong"):

El WebSocket de AppSync Events se cae en sesiones largas (blips de red, idle timeout, expiración del token Cognito) y **el cliente no reconectaba** — solo mostraba el error y se quedaba mudo, así que la respuesta del bot ya publicada nunca llegaba.

**Verificado vía AWS CLI** con la ejecución atascada (`b9b3ebf5`, "mejor para el 16"): el workflow generó el preview, lo persistió y publicó el evento, y quedó correctamente pausado en `WaitForConfirmation` (`TaskSubmitted`). El backend está sano; la pérdida era 100% de entrega en el cliente.

### Core Changes

- `AppSyncEventsClient`: **auto-reconexión** en cierre inesperado con backoff exponencial (1s→30s) y **token fresco**, luego re-`subscribe`. **Watchdog de inactividad** (usa `connectionTimeoutMs` del server, default 60s, se resetea con cada frame incluido el keep-alive) que fuerza reconexión si el enlace queda en silencio. `close()` deliberado no reconecta.
- Nuevo hook `onReconnect`: el drawer hace **backfill** de la sesión activa desde la BD al re-suscribir (Events no reenvía lo perdido mientras estuvo offline) y limpia el banner de error — sin skeleton, transparente a mitad de conversación.

### API / Data Changes

Ninguno (solo cliente). Sale por Amplify al mergear.

## Type of Change

- [x] Bug fix

## How to Test

1. Abrir el chat, registrar un gasto e **iterar** varias veces (cambiar fecha/monto). Las respuestas del bot llegan **en vivo** en cada iteración.
2. Dejar la conversación abierta un rato / simular caída de red → al volver, el socket reconecta solo y los mensajes pendientes aparecen sin recargar.
3. Ya no debe quedarse en el typing indicator indefinidamente ni mostrar "Something went wrong" de forma permanente.

## Checklist

- [x] Self-reviewed
- [x] No new warnings in format, lint, typecheck, or test
- [x] Tests añadidos (reconexión + no-reconexión tras close intencional); 153 tests de dashboard pasan

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)