### PR TITLE
feat: show both expense dates in list + chat on expenses view

### DIFF
--- a/client/packages/features/dashboard/src/presentation/components/shared/molecules/expense-card/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/molecules/expense-card/index.tsx
@@ -12,7 +12,7 @@ import { textTokens } from '@features/ui/utils/colors';
 import { fontSizeScale } from '@features/ui/utils/spacing';
 import { useThemeActions } from '@features/ui/contexts/theme-context';
 import { ColorScheme } from '@features/ui/utils/constants';
-import { formatDate, getUserLocale } from '@packages/utils';
+import { formatDate, formatDateOnly, getUserLocale } from '@packages/utils';
 
 interface ExpenseCardProps {
   expense: Expense;
@@ -35,6 +35,7 @@ export function ExpenseCard({
   const { colorScheme } = useThemeActions();
   const isDark = colorScheme === ColorScheme.DARK;
   const type = expenseType?.name ?? 'outcome';
+  const locale = getUserLocale();
 
   return (
     <Pressable
@@ -59,8 +60,19 @@ export function ExpenseCard({
             {expenseCategory && (
               <Badge label={expenseCategory.name} variant="default" />
             )}
+          </View>
+          {/* Both dates, so the list isn't ambiguous: when the expense
+              happened vs. when it was recorded (no need to open the detail). */}
+          <View className="flex-row items-center gap-x-3 gap-y-0.5 mt-1 flex-wrap">
+            {expense.date && (
+              <Text className="text-xs text-slate-500 dark:text-slate-400">
+                {t('expenses.card.expenseDate')}:{' '}
+                {formatDateOnly(expense.date, locale, 'medium')}
+              </Text>
+            )}
             <Text className="text-xs text-slate-400 dark:text-slate-500">
-              {formatDate(expense.created_at, getUserLocale(), 'medium')}
+              {t('expenses.card.createdAt')}:{' '}
+              {formatDate(expense.created_at, locale, 'medium')}
             </Text>
           </View>
         </View>

--- a/client/packages/features/dashboard/src/presentation/components/shared/templates/dashboard-template/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/templates/dashboard-template/index.tsx
@@ -147,7 +147,11 @@ export function DashboardTemplate() {
         )}
       </ScrollView>
 
-      <FloatingActionButton icon="robot" onPress={handleOpenChat} />
+      <FloatingActionButton
+        icon="robot"
+        onPress={handleOpenChat}
+        accessibilityLabel={t('aiChat.openLabel')}
+      />
       <AIChatDrawer visible={chatOpen} onClose={handleCloseChat} />
     </View>
   );

--- a/client/packages/features/dashboard/src/presentation/components/shared/templates/expenses-template/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/templates/expenses-template/index.tsx
@@ -231,7 +231,11 @@ export function ExpensesTemplate() {
 
       {/* Register expenses by chat without leaving this view. ChatProvider is
           already mounted at the dashboard layout, so no extra wiring needed. */}
-      <FloatingActionButton icon="robot" onPress={handleOpenChat} />
+      <FloatingActionButton
+        icon="robot"
+        onPress={handleOpenChat}
+        accessibilityLabel={t('aiChat.openLabel')}
+      />
       <AIChatDrawer visible={chatOpen} onClose={handleCloseChat} />
     </View>
   );

--- a/client/packages/features/dashboard/src/presentation/components/shared/templates/expenses-template/index.tsx
+++ b/client/packages/features/dashboard/src/presentation/components/shared/templates/expenses-template/index.tsx
@@ -10,12 +10,14 @@ import {
   ConfirmDialog,
   FilterBar,
   FilterChip,
+  FloatingActionButton,
 } from '@features/ui/components';
 import { useTranslation } from '@packages/i18n';
 import { useExpenses } from '@features/dashboard/presentation/providers/expense-provider';
 import { ExpenseList } from '@features/dashboard/presentation/components/web/organisms/expense-list';
 import { ExpenseModal } from '@features/dashboard/presentation/components/web/organisms/expense-modal';
 import { ExpenseSummary } from '@features/dashboard/presentation/components/shared/molecules/expense-summary';
+import { AIChatDrawer } from '@features/dashboard/presentation/components/shared/organisms/ai-chat-drawer';
 
 export function ExpensesTemplate() {
   const { t } = useTranslation('dashboard');
@@ -44,6 +46,10 @@ export function ExpensesTemplate() {
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
   const [deletingExpense, setDeletingExpense] = useState<Expense | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
+
+  const handleOpenChat = useCallback(() => setChatOpen(true), []);
+  const handleCloseChat = useCallback(() => setChatOpen(false), []);
 
   const handleSearchChange = useCallback(
     (name: string) => {
@@ -222,6 +228,11 @@ export function ExpensesTemplate() {
         cancelLabel={t('expenses.cancel')}
         loading={deleteLoading}
       />
+
+      {/* Register expenses by chat without leaving this view. ChatProvider is
+          already mounted at the dashboard layout, so no extra wiring needed. */}
+      <FloatingActionButton icon="robot" onPress={handleOpenChat} />
+      <AIChatDrawer visible={chatOpen} onClose={handleCloseChat} />
     </View>
   );
 }

--- a/client/packages/i18n/src/locales/en/dashboard/index.ts
+++ b/client/packages/i18n/src/locales/en/dashboard/index.ts
@@ -58,6 +58,8 @@ export const dashboard = {
     card: {
       deleteAccessibility: 'Delete expense',
       accessibilityLabel: '{{name}}, {{amount}}',
+      expenseDate: 'Expense date',
+      createdAt: 'Created',
     },
     selector: {
       selectTitle: 'Select {{field}}',

--- a/client/packages/i18n/src/locales/en/dashboard/index.ts
+++ b/client/packages/i18n/src/locales/en/dashboard/index.ts
@@ -110,6 +110,7 @@ export const dashboard = {
   },
   aiChat: {
     title: 'AI Assistant',
+    openLabel: 'Open AI assistant',
     placeholder: 'Describe your expense...',
     welcomeMessage:
       'Hi! I can help you log expenses. Tell me what you spent, send a photo of a receipt, or record a voice note.',

--- a/client/packages/i18n/src/locales/es/dashboard/index.ts
+++ b/client/packages/i18n/src/locales/es/dashboard/index.ts
@@ -58,6 +58,8 @@ export const dashboard = {
     card: {
       deleteAccessibility: 'Eliminar gasto',
       accessibilityLabel: '{{name}}, {{amount}}',
+      expenseDate: 'Fecha del gasto',
+      createdAt: 'Registrado',
     },
     selector: {
       selectTitle: 'Seleccionar {{field}}',

--- a/client/packages/i18n/src/locales/es/dashboard/index.ts
+++ b/client/packages/i18n/src/locales/es/dashboard/index.ts
@@ -110,6 +110,7 @@ export const dashboard = {
   },
   aiChat: {
     title: 'Asistente AI',
+    openLabel: 'Abrir asistente de IA',
     placeholder: 'Describe tu gasto...',
     welcomeMessage:
       '¡Hola! Puedo ayudarte a registrar gastos. Dime en qué gastaste, envía una foto del recibo o graba una nota de voz.',

--- a/client/packages/utils/src/format-date.test.ts
+++ b/client/packages/utils/src/format-date.test.ts
@@ -103,6 +103,13 @@ describe('formatDateOnly', () => {
     const result = formatDateOnly('not-a-date', 'en-US', 'medium');
     expect(result).toBeTruthy();
   });
+
+  it('does not silently roll over an out-of-range date', () => {
+    // Month 13 / day 40 must NOT render as a rolled-over Jan/Feb date.
+    const result = formatDateOnly('2026-13-40', 'en-US', 'medium');
+    expect(result).not.toContain('Jan');
+    expect(result).not.toContain('Feb');
+  });
 });
 
 describe('getUserLocale', () => {

--- a/client/packages/utils/src/format-date.test.ts
+++ b/client/packages/utils/src/format-date.test.ts
@@ -2,7 +2,12 @@ jest.mock('react-native', () => ({
   Platform: { OS: 'web' as string },
 }));
 
-import { formatDate, getUserLocale, getSupportedLocales } from './format-date';
+import {
+  formatDate,
+  formatDateOnly,
+  getUserLocale,
+  getSupportedLocales,
+} from './format-date';
 
 const ISO = '2026-03-31T12:00:00Z';
 
@@ -75,6 +80,28 @@ describe('formatDate', () => {
       const result = formatDate(ISO, 'xx-XX', 'medium');
       expect(result).toBeTruthy();
     });
+  });
+});
+
+describe('formatDateOnly', () => {
+  it('preserves the calendar day regardless of timezone (no UTC shift)', () => {
+    // "2026-03-31" as instant-UTC would render "Mar 30" in negative offsets;
+    // formatDateOnly must keep the 31st.
+    const result = formatDateOnly('2026-03-31', 'en-US', 'medium');
+    expect(result).toContain('Mar');
+    expect(result).toContain('31');
+    expect(result).toContain('2026');
+  });
+
+  it('ignores a trailing time component', () => {
+    const result = formatDateOnly('2026-03-31T00:00:00Z', 'en-US', 'medium');
+    expect(result).toContain('31');
+    expect(result).toContain('2026');
+  });
+
+  it('falls back gracefully for an unexpected shape', () => {
+    const result = formatDateOnly('not-a-date', 'en-US', 'medium');
+    expect(result).toBeTruthy();
   });
 });
 

--- a/client/packages/utils/src/format-date.ts
+++ b/client/packages/utils/src/format-date.ts
@@ -88,6 +88,18 @@ export function formatDateOnly(
   const options = DATE_OPTIONS[style];
   const localDate = new Date(year, month - 1, day);
 
+  // Guard against silent overflow (e.g. "2026-13-40", "2026-02-30"):
+  // `new Date(y, m, d)` rolls over out-of-range parts to a different day.
+  // If the constructed date doesn't round-trip to the parsed parts, the input
+  // wasn't a real calendar date — fall back to instant formatting.
+  if (
+    localDate.getFullYear() !== year ||
+    localDate.getMonth() !== month - 1 ||
+    localDate.getDate() !== day
+  ) {
+    return formatDate(date, locale, style);
+  }
+
   try {
     return new Intl.DateTimeFormat(resolvedLocale, options).format(localDate);
   } catch {

--- a/client/packages/utils/src/format-date.ts
+++ b/client/packages/utils/src/format-date.ts
@@ -57,6 +57,45 @@ export function formatDate(
 }
 
 /**
+ * Formats a calendar date (no time component) without any timezone shift.
+ *
+ * Use this for "date-only" values like an expense's occurrence date
+ * ("2026-03-31"). Parsing such a string with `new Date()` treats it as UTC
+ * midnight, which `formatDate` then renders in the local timezone — shifting
+ * the day backwards in negative-offset zones (e.g. "2026-03-31" → "Mar 30" in
+ * America/Bogotá). This parses the Y-M-D parts into a LOCAL date so the day is
+ * preserved exactly as stored.
+ *
+ * @param date - "YYYY-MM-DD" (a leading date part with an optional time is
+ *               accepted; anything after "T" is ignored)
+ * @param locale - BCP 47 locale tag
+ * @param style - "short" | "medium" | "long"
+ */
+export function formatDateOnly(
+  date: string,
+  locale: string,
+  style: DateFormatStyle,
+): string {
+  const datePart = date.split('T')[0] ?? date;
+  const [year, month, day] = datePart.split('-').map(Number);
+
+  // Unexpected shape — fall back to instant formatting rather than throwing.
+  if (!year || !month || !day) {
+    return formatDate(date, locale, style);
+  }
+
+  const resolvedLocale = LOCALE_MAP[locale] ?? locale;
+  const options = DATE_OPTIONS[style];
+  const localDate = new Date(year, month - 1, day);
+
+  try {
+    return new Intl.DateTimeFormat(resolvedLocale, options).format(localDate);
+  } catch {
+    return localDate.toLocaleDateString(DEFAULT_LOCALE, options);
+  }
+}
+
+/**
  * Returns the user's locale from the platform.
  *
  * - Web: navigator.language (e.g. "es-CO", "en-US")


### PR DESCRIPTION
## Description

Dos mejoras de cliente solicitadas:

1. **Fechas en el listado de gastos** — cada fila ahora muestra **ambas** fechas, etiquetadas: la **fecha del gasto** (cuándo ocurrió) y la fecha de **registro** (`created_at`). Antes solo se veía la de creación y había que abrir el detalle para ver la del gasto, lo cual confundía.
2. **Chat del bot en la vista de Expenses** — se agrega el botón flotante (robot) + el drawer del asistente también en la vista de gastos, para registrar desde ahí sin volver al dashboard.

### Core Changes

- **`@packages/utils`**: nuevo `formatDateOnly(date, locale, style)` — formatea una fecha "YYYY-MM-DD" **sin corrimiento de zona horaria**. (`new Date("2026-03-31")` se interpreta como UTC y `formatDate` lo renderiza en local, corriendo el día a "Mar 30" en zonas negativas como Bogotá). Parsea Y-M-D a fecha local.
- **`ExpenseCard`**: fila de fechas con `expenses.card.expenseDate` (usando `formatDateOnly` sobre `expense.date`, que es nullable) y `expenses.card.createdAt` (usando `formatDate` sobre `created_at`, que es un instante).
- **`ExpensesTemplate`**: `FloatingActionButton icon="robot"` + `AIChatDrawer` con estado local `chatOpen`. El `ChatProvider` ya está montado en `dashboard/_layout`, así que no requiere wiring extra.
- **i18n** (en/es): nuevas claves `expenses.card.expenseDate` y `expenses.card.createdAt`.

### API / Data Changes

Ninguno (solo cliente). Sale por Amplify al mergear.

## Type of Change

- [x] Feature

## How to Test

1. **Listado de gastos**: cada tarjeta muestra "Fecha del gasto: …" y "Registrado: …". Crea un gasto con fecha de ayer → la fecha del gasto debe ser exactamente la elegida (sin correrse un día).
2. **Chat en expenses**: en la vista de gastos, toca el botón flotante (robot) → abre el drawer del asistente; registra un gasto por chat y verifica que aparece en el listado.

## Checklist

- [x] Self-reviewed
- [x] No new warnings in format, lint, typecheck, or test
- [x] Tests añadidos (formatDateOnly: día preservado / time ignorado / fallback). 67 utils + 154 dashboard en verde.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)