### PR TITLE
fix: chat preview/confirmation show labels instead of catalog ids

### DIFF
--- a/infra/lib/versions/v2/step-functions-chat-stack.ts
+++ b/infra/lib/versions/v2/step-functions-chat-stack.ts
@@ -290,7 +290,9 @@ export class StepFunctionsChatStack extends BaseStack {
       model: claudeHaiku,
       body: claudeBody(
         PROMPTS.preview.system,
-        "States.Format('Gasto a registrar: {}', States.JsonToString($.validation.fields))",
+        // Feed the human-readable `display` (labels/codes), NOT `fields`
+        // (which carries catalog UUIDs that would leak into the message).
+        "States.Format('Gasto a registrar: {}', States.JsonToString($.validation.display))",
         PROMPTS.preview.maxTokens,
         PROMPTS.preview.temperature,
       ),
@@ -346,7 +348,9 @@ export class StepFunctionsChatStack extends BaseStack {
         model: claudeHaiku,
         body: claudeBody(
           PROMPTS.confirmation.system,
-          "States.Format('Gasto registrado: {}', States.JsonToString($.createResult.expense))",
+          // Use the human-readable `display` (labels/codes) instead of the
+          // created row, which carries catalog UUIDs.
+          "States.Format('Gasto registrado: {}', States.JsonToString($.validation.display))",
           PROMPTS.confirmation.maxTokens,
           PROMPTS.confirmation.temperature,
         ),

--- a/packages/prompts/src/chat/prompts-content.test.ts
+++ b/packages/prompts/src/chat/prompts-content.test.ts
@@ -70,6 +70,13 @@ describe('user-facing response prompts', () => {
     expect(CONFIRMATION_SYSTEM_PROMPT).toContain('moneda');
   });
 
+  it('preview and confirmation forbid leaking internal identifiers', () => {
+    expect(PREVIEW_SYSTEM_PROMPT).toContain('NUNCA muestres identificadores');
+    expect(CONFIRMATION_SYSTEM_PROMPT).toContain(
+      'NUNCA muestres identificadores',
+    );
+  });
+
   it('cancellation states the expense was NOT saved', () => {
     expect(CANCELLATION_SYSTEM_PROMPT).toContain('NO fue guardado');
   });

--- a/packages/prompts/src/chat/responses.ts
+++ b/packages/prompts/src/chat/responses.ts
@@ -9,14 +9,16 @@ Si te muestran datos de gastos del usuario, usá montos con dos decimales y la m
 No inventes información que no esté en los datos.`;
 
 export const PREVIEW_SYSTEM_PROMPT = `Eres un asistente que genera vistas previas de gastos antes de guardarlos.
-Dado un gasto que el usuario quiere registrar, devolvé un mensaje corto en español que:
-1. Resume el gasto (nombre, monto + moneda, categoría, fecha) en una sola línea.
+Recibís un gasto con valores YA legibles: moneda como código (ej: "COP"), tipo y categoría como texto. Devolvé un mensaje corto en español que:
+1. Resume el gasto (nombre, monto + moneda, tipo, categoría si está, fecha) en una sola línea.
 2. Pregunta explícitamente "¿Confirmás?" al final.
+Usá EXACTAMENTE los valores provistos. NUNCA muestres identificadores internos (UUID) ni inventes datos que no aparezcan.
 Sin markdown ni listas, sólo prosa.`;
 
 export const CONFIRMATION_SYSTEM_PROMPT = `Eres un asistente que confirma que un gasto fue registrado.
-Devolvé un mensaje muy corto en español (una oración) que confirme el registro.
-Incluí el monto. Mencioná la moneda sólo si aparece explícita en los datos (ej: "COP", "USD"); si sólo ves un identificador interno, omitila — NUNCA la adivines.
+Recibís el gasto con valores legibles: moneda como código (ej: "COP").
+Devolvé un mensaje muy corto en español (una oración) que confirme el registro, incluyendo el monto y la moneda.
+NUNCA muestres identificadores internos (UUID) ni inventes datos que no aparezcan.
 Empezá con un emoji positivo.`;
 
 export const CANCELLATION_SYSTEM_PROMPT = `Eres un asistente que confirma que un gasto fue descartado por el usuario.

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.test.ts
@@ -32,6 +32,13 @@ describe('ValidateExpenseFieldsUseCase', () => {
       currency_id: 'cur-1',
       expense_type_id: 'type-1',
     });
+    // Human-readable mirror for the preview/confirmation — labels, never IDs.
+    expect(result.display).toEqual({
+      name: 'Cena',
+      value: 45,
+      currency: 'USD',
+      type: 'egreso',
+    });
   });
 
   it('maps Spanish expense type synonyms to catalog names before lookup', async () => {
@@ -195,6 +202,8 @@ describe('ValidateExpenseFieldsUseCase', () => {
 
     expect(result.complete).toBe(true);
     expect(result.fields?.expense_category_id).toBe('cat-comida');
+    // The preview shows the category NAME, not its id.
+    expect(result.display?.category).toBe('comida');
   });
 
   it('passes through the date when provided', async () => {
@@ -212,5 +221,25 @@ describe('ValidateExpenseFieldsUseCase', () => {
     });
 
     expect(result.fields?.date).toBe('2026-06-15');
+    expect(result.display?.date).toBe('2026-06-15');
+  });
+
+  it('omits the category from display when it does not resolve', async () => {
+    const catalog = makeMockCatalog();
+    catalog.findCurrencyIdByCode.mockResolvedValue('cur-1');
+    catalog.findExpenseTypeIdByName.mockResolvedValue('type-1');
+    catalog.findCategoryIdByName.mockResolvedValue(null);
+    const useCase = new ValidateExpenseFieldsUseCase(catalog);
+
+    const result = await useCase.execute({
+      name: 'Cena',
+      value: 45,
+      currencyCode: 'USD',
+      expenseTypeName: 'egreso',
+      categoryName: 'inexistente',
+    });
+
+    expect(result.complete).toBe(true);
+    expect(result.display?.category).toBeUndefined();
   });
 });

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
@@ -27,7 +27,7 @@ export interface ExpenseDisplayFields {
   value: number;
   /** Currency CODE (e.g. "COP"), never the currency id. */
   currency: string;
-  /** "ingreso" | "egreso" (or the raw catalog name as a fallback). */
+  /** "ingreso" | "egreso" (or the raw extracted value as a fallback). */
   type: string;
   /** Category NAME, present only when it resolved against the catalog. */
   category?: string;

--- a/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
+++ b/services/chat/src/application/use-cases/validate-expense-fields.use-case.ts
@@ -17,10 +17,33 @@ export interface ResolvedExpenseFields {
   date?: string;
 }
 
+/**
+ * Human-readable version of the resolved fields, for the user-facing preview
+ * and confirmation messages. NEVER contains catalog IDs — those leak into the
+ * chat as opaque UUIDs otherwise.
+ */
+export interface ExpenseDisplayFields {
+  name: string;
+  value: number;
+  /** Currency CODE (e.g. "COP"), never the currency id. */
+  currency: string;
+  /** "ingreso" | "egreso" (or the raw catalog name as a fallback). */
+  type: string;
+  /** Category NAME, present only when it resolved against the catalog. */
+  category?: string;
+  /** "YYYY-MM-DD", present only when the user gave a date. */
+  date?: string;
+}
+
 export interface ValidateExpenseFieldsResult {
   complete: boolean;
   /** When `complete` is true, the resolved fields ready to create. */
   fields?: ResolvedExpenseFields;
+  /**
+   * When `complete` is true, the same expense in human-readable form for the
+   * preview/confirmation prompts (labels, not IDs).
+   */
+  display?: ExpenseDisplayFields;
   /** When `complete` is false, the friendly names of what is missing. */
   missing: string[];
   /**
@@ -46,6 +69,14 @@ const FRIENDLY_LABELS = {
   expense_type: 'tipo (ingreso o egreso)',
   date: 'fecha',
 } as const;
+
+/** Maps the catalog expense-type name to a Spanish label for the preview. */
+function toDisplayExpenseType(name: string): string {
+  const catalog = toCatalogExpenseTypeName(name);
+  if (catalog === 'income') return 'ingreso';
+  if (catalog === 'outcome') return 'egreso';
+  return name;
+}
 
 /**
  * Validates the AI-extracted fields:
@@ -123,6 +154,18 @@ export class ValidateExpenseFieldsUseCase {
       ...(extracted.date !== undefined && { date: extracted.date }),
     };
 
-    return { complete: true, fields, missing: [] };
+    // Human-readable mirror for the preview/confirmation prompts — labels
+    // only, so the assistant never echoes catalog UUIDs back to the user.
+    const display: ExpenseDisplayFields = {
+      name: extracted.name!,
+      value: extracted.value!,
+      currency: extracted.currencyCode!.toUpperCase(),
+      type: toDisplayExpenseType(extracted.expenseTypeName!),
+      ...(categoryId !== null &&
+        extracted.categoryName && { category: extracted.categoryName }),
+      ...(extracted.date !== undefined && { date: extracted.date }),
+    };
+
+    return { complete: true, fields, display, missing: [] };
   }
 }


### PR DESCRIPTION
## Description

El bot mostraba **identificadores internos** en lugar de texto legible:

> Vas a registrar un gasto de Pago Keybe por 100000 (la moneda asociada al ID `98bbfdec-…`) en la categoría `c04479e4-…` para el 17 de junio de 2026. ¿Confirmás?

**Causa raíz:** `GeneratePreview` se alimentaba de `$.validation.fields` (IDs ya resueltos: `currency_id`, `expense_category_id`, `expense_type_id`) y `GenerateConfirmation` del registro creado (también con IDs). El LLM repetía esos UUID.

### Core Changes

- **`ValidateExpenseFields`** ahora devuelve, además de `fields` (IDs, para crear), un objeto **`display`** legible: `currency` (código, ej "COP"), `type` (`ingreso`/`egreso`), `category` (nombre, solo si resolvió) y `date`.
- **ASL**: `GeneratePreview` y `GenerateConfirmation` formatean desde `$.validation.display` en vez de los payloads con IDs.
- **Prompts** (`@packages/prompts`): preview y confirmation actualizados para usar los labels provistos y **NUNCA** emitir identificadores internos (se conservan "¿Confirmás?" y "monto"/"moneda").

### API / Data Changes

- Sin cambios de schema. **Requiere redeploy de `FinancialManagement-v2-StepFunctionsChat`** (el ASL embebe el texto del prompt en synth) — el CI lo hace al mergear a main.

## Type of Change

- [x] Bug fix

## How to Test

1. Por chat: "Necesito crear un gasto" → dar descripción, monto, moneda (ej COP), tipo y categoría.
2. El preview debe decir algo como: *"Vas a registrar **Pago Keybe** por **100000 COP** (egreso) en la categoría **Servicios** para el 17 de junio de 2026. ¿Confirmás?"* — **sin UUIDs**.
3. Confirmar → el mensaje de confirmación tampoco debe mostrar identificadores.

## Checklist

- [x] Self-reviewed
- [x] No new warnings in format, lint, typecheck, or test
- [x] Tests: `display` en ValidateExpenseFields (moneda/tipo/categoría/fecha + categoría omitida si no resuelve) y prompts que prohíben identificadores. 61 chat + 25 prompts + 18 infra SFN en verde.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)